### PR TITLE
fix(asset): align registration actions with badge styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -118,6 +118,27 @@
     line-height: 1;
 }
 
+.badge-button {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.badge-button.badge {
+    padding: 0.2rem 0.5rem;
+}
+
+.badge-button:focus-visible {
+    outline: 2px solid #0b57d0;
+    outline-offset: 2px;
+}
+
+
 .badge--available {
     background: #e9f8ee;
     color: #177245;
@@ -139,7 +160,7 @@
     color: #b71c1c;
 }
 
-/* 관리단�?배�? ?��???*/
+/* ê´€ë¦¬ë‹¨ê³?ë°°ì? ?¤í???*/
 .badge--pending {
     background: #fff4e5;
     color: #f59e0b;
@@ -194,7 +215,7 @@
     transition: all 0.2s ease;
 }
 
-/* 진단 코드 모달 ?��???*/
+/* ì§„ë‹¨ ì½”ë“œ ëª¨ë‹¬ ?¤í???*/
 .diagnostic-detail {
     padding: 0;
 }

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -607,7 +607,12 @@ export default function AssetStatus() {
                     );
                 }
                 return (
-                    <button type="button" className="form-button" onClick={() => openInsuranceModal(row)}>
+                    <button
+                        type="button"
+                        className="badge-button badge badge--default badge--clickable"
+                        onClick={() => openInsuranceModal(row)}
+                        title="보험 등록"
+                    >
                         보험 등록
                     </button>
                 );
@@ -762,22 +767,21 @@ export default function AssetStatus() {
                           const stored = typedStorage.devices.getInfo(row.id) || {};
                           const hasDevice = row.deviceSerial || stored.serial;
                           if (hasDevice) {
-                              return (
-                                  <button
-                                      type="button"
-                                      className="badge badge--on badge--clickable"
-                                      style={{ cursor: "pointer", border: "none", background: "transparent" }}
-                                      onClick={() => openDeviceView(row)}
-                                      title="단말 정보 보기"
-                                  >
-                                      연결됨
-                                  </button>
-                              );
-                          }
                           return (
                               <button
                                   type="button"
-                                  className="form-button"
+                                  className="badge-button badge badge--on badge--clickable"
+                                  onClick={() => openDeviceView(row)}
+                                  title="단말 정보 보기"
+                              >
+                                  연결됨
+                              </button>
+                          );
+                      }
+                          return (
+                              <button
+                                  type="button"
+                                  className="badge-button badge badge--default badge--clickable"
                                   onClick={() => openDeviceRegister(row)}
                                   title="단말 등록"
                               >


### PR DESCRIPTION
## Summary
- add a reusable badge-button helper style to support clickable pills without default button chrome
- update the 보험 등록 and 단말 등록 table actions to reuse badge styling for a consistent look

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1259a19f88332ae419ff77296ecc8