### PR TITLE
feat: redesign management stage dropdown badges

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -215,6 +215,63 @@
     transition: all 0.2s ease;
 }
 
+.management-stage-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 4px 0;
+    min-width: 180px;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12);
+    z-index: 20;
+}
+
+.management-stage-dropdown li {
+    list-style: none;
+}
+
+.management-stage-dropdown__option {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    padding: 8px 12px;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.management-stage-dropdown__badge {
+    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+}
+
+.management-stage-dropdown__option:hover,
+.management-stage-dropdown__option:focus-visible {
+    background: #f3f4f6;
+}
+
+.management-stage-dropdown__option:disabled {
+    cursor: not-allowed;
+    color: #9ca3af;
+}
+
+.management-stage-dropdown__option:disabled .badge {
+    opacity: 0.6;
+}
+
+.management-stage-dropdown__option:disabled .management-stage-dropdown__badge {
+    cursor: not-allowed;
+}
+
 /* ì§„ë‹¨ ì½”ë“œ ëª¨ë‹¬ ?¤í???*/
 .diagnostic-detail {
     padding: 0;


### PR DESCRIPTION
## Summary
- replace the management-stage select control with a badge-styled trigger and dropdown menu
- add outside-click and Escape handling to close the new menu safely
- style the dropdown options with contextual badge colors for each stage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d128d486708332a26da20b715c3c4f