### PR TITLE
fix: keep headers sticky on asset and rental tables

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,18 @@
     font-weight: 600;
 }
 
+.table-wrap--sticky {
+    position: relative;
+}
+
+.asset-table--sticky thead th {
+    position: sticky;
+    top: var(--table-sticky-offset, 0px);
+    z-index: 5;
+    background: #fafafa;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
 /* Asset/toolbars: align controls consistently */
 .asset-toolbar {
     display: flex;

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -8,19 +8,36 @@ export default function Table({
     onRowClick,
     className = "",
     emptyMessage = "데이터가 없습니다.",
+    stickyHeader = false,
+    stickyOffset = 0,
     ...props
 }) {
     const { selected, toggleSelect, toggleSelectAllVisible, allVisibleSelected } = selection || {};
     const hasSelection = !!selection;
 
+    const wrapClassNames = ["table-wrap"];
+    const tableClassNames = ["asset-table", className];
+
+    if (stickyHeader) {
+        wrapClassNames.push("table-wrap--sticky");
+        tableClassNames.push("asset-table--sticky");
+    }
+
+    const stickyStyle = stickyHeader
+        ? {
+              "--table-sticky-offset":
+                  typeof stickyOffset === "number" ? `${stickyOffset}px` : stickyOffset || "0px",
+          }
+        : undefined;
+
     return (
-        <div className="table-wrap">
-            <table className={`asset-table ${className}`} {...props}>
+        <div className={wrapClassNames.filter(Boolean).join(" ")} style={stickyStyle}>
+            <table className={tableClassNames.filter(Boolean).join(" ")} {...props}>
                 <thead>
                     <tr>
                         {hasSelection && (
                             <th style={{ width: DIMENSIONS.ICON_SIZE_LG, textAlign: "center" }}>
-                                <input 
+                                <input
                                     type="checkbox" 
                                     aria-label="현재 목록 전체 선택" 
                                     checked={allVisibleSelected} 

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -1072,7 +1072,14 @@ export default function AssetStatus() {
                 <DeviceEventLog assetId={activeAsset?.id} fallbackInstallDate={deviceInitial?.installDate || "" || activeAsset?.deviceInstallDate || activeAsset?.installDate || ""} />
             </Modal>
 
-            <Table columns={dynamicColumns} data={filtered} selection={selection} emptyMessage="조건에 맞는 차량 자산이 없습니다." />
+            <Table
+                columns={dynamicColumns}
+                data={filtered}
+                selection={selection}
+                emptyMessage="조건에 맞는 차량 자산이 없습니다."
+                stickyHeader
+                stickyOffset={DIMENSIONS.HEADER_HEIGHT}
+            />
 
             {/* inline panel removed */}
             <Modal

--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -6,6 +6,7 @@ import AccidentInfoModal from "../components/AccidentInfoModal";
 import useTableSelection from "../hooks/useTableSelection";
 import StatusBadge from "../components/StatusBadge";
 import KakaoMap from "../components/KakaoMap";
+import { DIMENSIONS } from "../constants";
 import { FaCar, FaEdit, FaSave, FaTimes, FaExclamationTriangle, FaMapMarkerAlt, FaCog, FaEye, FaEyeSlash, FaGripVertical } from "react-icons/fa";
 import { FiAlertTriangle } from "react-icons/fi";
 
@@ -748,8 +749,11 @@ export default function RentalContracts() {
                     </div>
                 </div>
 
-                <div className="table-wrap">
-                    <table className="asset-table rentals-table">
+                <div
+                    className="table-wrap table-wrap--sticky"
+                    style={{ "--table-sticky-offset": `${DIMENSIONS.HEADER_HEIGHT}px` }}
+                >
+                    <table className="asset-table rentals-table asset-table--sticky">
                         <thead>
                             <tr>
                                 {visibleColumns.map((column) => (


### PR DESCRIPTION
## Summary
- add optional sticky header support to the shared Table component and enable it for the asset list
- reuse the sticky styling in the rental contracts table and share offset through constants
- introduce CSS helpers to keep table headers visible while scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d146b964a483329daf7a92f9a1d793