### PR TITLE
fix: adjust seed data for consistent rental scenarios

### DIFF
--- a/src/data/seed.json
+++ b/src/data/seed.json
@@ -17,16 +17,53 @@
       "deviceInstallDate": "2025-02-01",
       "deviceSerial": "1ABCD-SONATA-26",
       "memo": "엔진오일 교체 완료",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2025",
       "insuranceExpiryDate": "2026-11-01",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-11-01", "company": "렌터카공제", "product": "", "startDate": "2024-11-01", "expiryDate": "2025-11-01", "specialTerms": "", "docName": "", "docDataUrl": "" },
-        { "type": "갱신", "date": "2025-11-01", "company": "렌터카공제", "product": "", "startDate": "2025-11-01", "expiryDate": "2026-11-01", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-11-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-11-01",
+          "expiryDate": "2025-11-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-11-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2025-11-01",
+          "expiryDate": "2026-11-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-11-01", "installDate": "2024-11-01", "serial": "1ABCD-SONATA-25", "installer": "김범기" },
-        { "type": "replace", "date": "2025-02-01", "installDate": "2025-02-01", "serial": "1ABCD-SONATA-26", "installer": "이상훈" }
+        {
+          "type": "install",
+          "date": "2024-11-01",
+          "installDate": "2024-11-01",
+          "serial": "1ABCD-SONATA-25",
+          "installer": "김범기"
+        },
+        {
+          "type": "replace",
+          "date": "2025-02-01",
+          "installDate": "2025-02-01",
+          "serial": "1ABCD-SONATA-26",
+          "installer": "이상훈"
+        }
       ]
     },
     "rental": [
@@ -38,26 +75,41 @@
         "renter_name": "김민수",
         "contact_number": "+82-10-1234-5678",
         "address": "서울특별시 종로구",
-        "rental_period": { "start": "2025-08-20T09:00:00", "end": "2026-08-30T18:00:00" },
-        "insurance_name": "현대해상",
-        "rental_location": { "lat": 37.5665, "lng": 126.978 },
-        "return_location": { "lat": 37.4563, "lng": 126.7052 },
-        "current_location": { "lat": 37.55, "lng": 126.99 },
+        "rental_period": {
+          "start": "2025-09-10T09:00:00",
+          "end": "2025-10-10T18:00:00"
+        },
+        "insurance_name": "렌터카공제",
+        "rental_location": {
+          "lat": 37.5665,
+          "lng": 126.978
+        },
+        "return_location": {
+          "lat": 37.4563,
+          "lng": 126.7052
+        },
+        "current_location": {
+          "lat": 37.5521,
+          "lng": 126.9898
+        },
         "engine_status": "on",
         "restart_blocked": false,
         "accident_reported": true,
         "accidentReport": {
-          "accidentDate": "2025-09-22",
+          "accidentDate": "2025-09-18",
           "accidentHour": "14",
           "accidentMinute": "30",
           "accidentSecond": "15",
           "handlerName": "박상현",
-          "accidentDateTime": "2025-09-22T14:30:15",
-          "accidentDisplayTime": "2025.09.22 14:30:15",
+          "accidentDateTime": "2025-09-18T14:30:15",
+          "accidentDisplayTime": "2025.09.18 14:30:15",
           "blackboxFile": null,
           "blackboxFileName": "blackbox_250922.mp4",
-          "recordedAt": "2025-09-22T14:45:00.000Z"
-        }
+          "recordedAt": "2025-09-18T14:45:00.000Z"
+        },
+        "rental_amount": 1580000,
+        "contract_status": "진행중",
+        "memo": "장기 렌트 고객 - 정기 점검 예약"
       },
       {
         "rental_id": 100000000090,
@@ -67,13 +119,24 @@
         "renter_name": "이정훈",
         "contact_number": "+82-10-2222-3333",
         "address": "서울특별시 강남구",
-        "rental_period": { "start": "2025-03-01T09:00:00", "end": "2025-06-01T18:00:00" },
-        "insurance_name": "DB손해보험",
-        "rental_location": { "lat": 37.498, "lng": 127.027 },
-        "return_location": { "lat": 37.498, "lng": 127.027 },
+        "rental_period": {
+          "start": "2025-03-01T09:00:00",
+          "end": "2025-06-01T18:00:00"
+        },
+        "insurance_name": "렌터카공제",
+        "rental_location": {
+          "lat": 37.498,
+          "lng": 127.027
+        },
+        "return_location": {
+          "lat": 37.498,
+          "lng": 127.027
+        },
         "current_location": null,
         "engine_status": "off",
-        "restart_blocked": false
+        "restart_blocked": false,
+        "contract_status": "완료",
+        "return_confirmed": true
       }
     ]
   },
@@ -95,16 +158,53 @@
       "deviceInstallDate": "2025-01-05",
       "deviceSerial": "KIA-SPTG-19-XY99",
       "memo": "배터리 교체 예정",
-      "diagnosticCodes": { "category1": 2, "category2": 1, "category3": 0, "category4": 3 },
+      "diagnosticCodes": {
+        "category1": 2,
+        "category2": 1,
+        "category3": 0,
+        "category4": 3
+      },
       "insuranceInfo": "렌터카공제 2025",
       "insuranceExpiryDate": "2026-10-15",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-11-01", "company": "렌터카공제", "product": "", "startDate": "2024-11-01", "expiryDate": "2025-10-15", "specialTerms": "", "docName": "", "docDataUrl": "" },
-        { "type": "갱신", "date": "2025-10-15", "company": "렌터카공제", "product": "", "startDate": "2025-10-15", "expiryDate": "2026-10-15", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-11-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-11-01",
+          "expiryDate": "2025-10-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-10-15",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2025-10-15",
+          "expiryDate": "2026-10-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-11-01", "installDate": "2024-11-01", "serial": "KIA-SPTG-19-ABCE", "installer": "김범기" },
-        { "type": "replace", "date": "2025-01-05", "installDate": "2025-01-05", "serial": "KIA-SPTG-19-XY99", "installer": "김범기" }
+        {
+          "type": "install",
+          "date": "2024-11-01",
+          "installDate": "2024-11-01",
+          "serial": "KIA-SPTG-19-ABCE",
+          "installer": "김범기"
+        },
+        {
+          "type": "replace",
+          "date": "2025-01-05",
+          "installDate": "2025-01-05",
+          "serial": "KIA-SPTG-19-XY99",
+          "installer": "김범기"
+        }
       ]
     },
     "rental": [
@@ -116,13 +216,28 @@
         "renter_name": "박지현",
         "contact_number": "+82-10-7777-8888",
         "address": "부산광역시 해운대구",
-        "rental_period": { "start": "2025-08-28T10:30:00", "end": "2025-09-05T17:00:00" },
+        "rental_period": {
+          "start": "2025-09-01T10:30:00",
+          "end": "2025-09-28T17:00:00"
+        },
         "insurance_name": "한화손해보험",
-        "rental_location": { "lat": 35.1796, "lng": 129.0756 },
-        "return_location": { "lat": 35.1796, "lng": 129.0756 },
-        "current_location": { "lat": 35.2, "lng": 129.08 },
-        "engine_status": "off",
-        "restart_blocked": true
+        "rental_location": {
+          "lat": 35.1796,
+          "lng": 129.0756
+        },
+        "return_location": {
+          "lat": 35.1796,
+          "lng": 129.0756
+        },
+        "current_location": {
+          "lat": 35.205,
+          "lng": 129.082
+        },
+        "engine_status": "on",
+        "restart_blocked": true,
+        "rental_amount": 880000,
+        "contract_status": "진행중",
+        "memo": "차량 반납 전 누유 점검 필요"
       },
       {
         "rental_id": 100000000180,
@@ -132,13 +247,24 @@
         "renter_name": "오세훈",
         "contact_number": "+82-10-2222-1111",
         "address": "부산광역시 수영구",
-        "rental_period": { "start": "2025-05-01T09:00:00", "end": "2025-05-08T18:00:00" },
+        "rental_period": {
+          "start": "2025-05-01T09:00:00",
+          "end": "2025-05-08T18:00:00"
+        },
         "insurance_name": "DB손해보험",
-        "rental_location": { "lat": 35.18, "lng": 129.07 },
-        "return_location": { "lat": 35.18, "lng": 129.07 },
+        "rental_location": {
+          "lat": 35.18,
+          "lng": 129.07
+        },
+        "return_location": {
+          "lat": 35.18,
+          "lng": 129.07
+        },
         "current_location": null,
         "engine_status": "off",
-        "restart_blocked": false
+        "restart_blocked": false,
+        "contract_status": "완료",
+        "return_confirmed": true
       }
     ]
   },
@@ -155,17 +281,28 @@
       "vin": "5YJ3E1EA7KF123456",
       "registrationDate": "2024-11-01",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "보험미등록",
       "installer": "김범기",
       "deviceInstallDate": "2024-11-01",
       "deviceSerial": "HYU-GRAN-23-ABCF",
-      "memo": "에어필터 교체 완료",
-      "diagnosticCodes": { "category1": 0, "category2": 2, "category3": 1, "category4": 0 },
+      "memo": "보험 가입 대기중",
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 2,
+        "category3": 1,
+        "category4": 0
+      },
       "insuranceInfo": "",
       "insuranceExpiryDate": "",
       "insuranceHistory": [],
       "deviceHistory": [
-        { "type": "install", "date": "2024-11-01", "installDate": "2024-11-01", "serial": "HYU-GRAN-23-ABCF", "installer": "김범기" }
+        {
+          "type": "install",
+          "date": "2024-11-01",
+          "installDate": "2024-11-01",
+          "serial": "HYU-GRAN-23-ABCF",
+          "installer": "김범기"
+        }
       ]
     },
     "rental": []
@@ -183,20 +320,51 @@
       "vin": "WAUZZZF40LA123456",
       "registrationDate": "2024-11-01",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "반납대기",
+      "vehicleStatus": "반납지연",
       "installer": "김범기",
       "deviceInstallDate": "2024-11-01",
       "deviceSerial": "KIA-SORE-24-ABCG",
       "memo": "타이어 교체 예정",
-      "diagnosticCodes": { "category1": 1, "category2": 0, "category3": 4, "category4": 1 },
+      "diagnosticCodes": {
+        "category1": 1,
+        "category2": 0,
+        "category3": 4,
+        "category4": 1
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-11-01",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-11-01", "company": "렌터카공제", "product": "", "startDate": "2024-11-01", "expiryDate": "2025-11-01", "specialTerms": "", "docName": "", "docDataUrl": "" },
-        { "type": "갱신", "date": "2025-11-01", "company": "렌터카공제", "product": "", "startDate": "2025-11-01", "expiryDate": "2026-11-01", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-11-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-11-01",
+          "expiryDate": "2025-11-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-11-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2025-11-01",
+          "expiryDate": "2026-11-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-11-01", "installDate": "2024-11-01", "serial": "KIA-SORE-24-ABCG", "installer": "김범기" }
+        {
+          "type": "install",
+          "date": "2024-11-01",
+          "installDate": "2024-11-01",
+          "serial": "KIA-SORE-24-ABCG",
+          "installer": "김범기"
+        }
       ]
     },
     "rental": [
@@ -208,13 +376,27 @@
         "renter_name": "최아름",
         "contact_number": "+82-10-7777-8888",
         "address": "대구광역시 수성구",
-        "rental_period": { "start": "2025-08-30T08:00:00", "end": "2025-09-08T20:00:00" },
+        "rental_period": {
+          "start": "2025-09-05T08:00:00",
+          "end": "2025-09-12T20:00:00"
+        },
         "insurance_name": "메리츠화재",
-        "rental_location": { "lat": 35.8714, "lng": 128.6014 },
-        "return_location": { "lat": 35.8714, "lng": 128.6014 },
-        "current_location": { "lat": 35.8714, "lng": 128.6014 },
-        "engine_status": "on",
-        "restart_blocked": false
+        "rental_location": {
+          "lat": 35.8714,
+          "lng": 128.6014
+        },
+        "return_location": {
+          "lat": 35.8714,
+          "lng": 128.6014
+        },
+        "current_location": {
+          "lat": 35.882,
+          "lng": 128.61
+        },
+        "engine_status": "off",
+        "restart_blocked": true,
+        "contract_status": "반납지연",
+        "memo": "고객 연락 두절 - 회수 진행중"
       }
     ]
   },
@@ -236,15 +418,46 @@
       "deviceInstallDate": "2023-01-01",
       "deviceSerial": "LR-EVOQ-24-7722",
       "memo": "프리미엄 고객용",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-01-01",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-01-01", "company": "렌터카공제", "product": "", "startDate": "2023-01-01", "expiryDate": "2024-01-01", "specialTerms": "", "docName": "", "docDataUrl": "" },
-        { "type": "갱신", "date": "2024-01-01", "company": "렌터카공제", "product": "", "startDate": "2024-01-01", "expiryDate": "2025-01-01", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-01-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2023-01-01",
+          "expiryDate": "2024-01-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2024-01-01",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-01-01",
+          "expiryDate": "2025-01-01",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2023-01-01", "installDate": "2023-01-01", "serial": "LR-EVOQ-24-7722", "installer": "외부 설치" }
+        {
+          "type": "install",
+          "date": "2023-01-01",
+          "installDate": "2023-01-01",
+          "serial": "LR-EVOQ-24-7722",
+          "installer": "외부 설치"
+        }
       ]
     },
     "rental": [
@@ -256,13 +469,27 @@
         "renter_name": "정도윤",
         "contact_number": "+82-10-1111-2222",
         "address": "광주광역시 서구",
-        "rental_period": { "start": "2025-09-05", "end": "2025-09-20" },
+        "rental_period": {
+          "start": "2025-09-12T09:00:00",
+          "end": "2025-09-27T18:00:00"
+        },
         "insurance_name": "삼성화재",
-        "rental_location": { "lat": 35.1595, "lng": 126.8526 },
-        "return_location": { "lat": 35.1595, "lng": 126.8526 },
-        "current_location": { "lat": 35.17, "lng": 126.86 },
+        "rental_location": {
+          "lat": 35.1595,
+          "lng": 126.8526
+        },
+        "return_location": {
+          "lat": 35.1595,
+          "lng": 126.8526
+        },
+        "current_location": {
+          "lat": 35.17,
+          "lng": 126.86
+        },
         "engine_status": "on",
-        "restart_blocked": false
+        "restart_blocked": false,
+        "rental_amount": 2450000,
+        "contract_status": "진행중"
       }
     ]
   },
@@ -279,19 +506,50 @@
       "vin": "WP0ZZZ99ZTS123456",
       "registrationDate": "2022-03-15",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "정비중",
       "installer": "지점A",
       "deviceSerial": "KIA-MORN-20-3456",
-      "memo": "브레이크 패드 교체 완료",
-      "diagnosticCodes": { "category1": 8, "category2": 7, "category3": 5, "category4": 9 },
+      "memo": "브레이크 패드 교체 예약 (09/25)",
+      "diagnosticCodes": {
+        "category1": 8,
+        "category2": 7,
+        "category3": 5,
+        "category4": 9
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-03-15",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-03-15", "company": "렌터카공제", "product": "", "startDate": "2023-03-15", "expiryDate": "2024-03-15", "specialTerms": "", "docName": "", "docDataUrl": "" },
-        { "type": "갱신", "date": "2024-03-15", "company": "렌터카공제", "product": "", "startDate": "2024-03-15", "expiryDate": "2025-03-15", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-03-15",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2023-03-15",
+          "expiryDate": "2024-03-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2024-03-15",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-03-15",
+          "expiryDate": "2025-03-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2022-03-15", "installDate": "2022-03-15", "serial": "KIA-MORN-20-3456", "installer": "지점A" }
+        {
+          "type": "install",
+          "date": "2022-03-15",
+          "installDate": "2022-03-15",
+          "serial": "KIA-MORN-20-3456",
+          "installer": "지점A"
+        }
       ]
     },
     "rental": [
@@ -303,13 +561,27 @@
         "renter_name": "이혜진",
         "contact_number": "+82-10-5555-6666",
         "address": "제주특별자치도 제주시",
-        "rental_period": { "start": "2025-08-20", "end": "2025-08-25" },
+        "rental_period": {
+          "start": "2025-07-10T09:00:00",
+          "end": "2025-07-14T18:00:00"
+        },
         "insurance_name": "메리츠화재",
-        "rental_location": { "lat": 33.4996, "lng": 126.5312 },
-        "return_location": { "lat": 33.4996, "lng": 126.5312 },
-        "current_location": { "lat": 33.51, "lng": 126.54 },
+        "rental_location": {
+          "lat": 33.4996,
+          "lng": 126.5312
+        },
+        "return_location": {
+          "lat": 33.4996,
+          "lng": 126.5312
+        },
+        "current_location": {
+          "lat": 33.4996,
+          "lng": 126.5312
+        },
         "engine_status": "off",
-        "restart_blocked": true
+        "restart_blocked": false,
+        "contract_status": "완료",
+        "return_confirmed": true
       }
     ]
   },
@@ -326,19 +598,40 @@
       "vin": "KMHAB51DBMU123457",
       "registrationDate": "2025-01-15",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "대기중",
       "installer": "지점B",
       "deviceInstallDate": "2025-01-15",
       "deviceSerial": "GEN-GV80-24-0234",
       "memo": "신차 초기 점검 완료",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2026-01-15",
       "insuranceHistory": [
-        { "type": "등록", "date": "2025-01-15", "company": "렌터카공제", "product": "", "startDate": "2025-01-15", "expiryDate": "2026-01-15", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2025-01-15",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2025-01-15",
+          "expiryDate": "2026-01-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2025-01-15", "installDate": "2025-01-15", "serial": "GEN-GV80-24-0234", "installer": "지점B" }
+        {
+          "type": "install",
+          "date": "2025-01-15",
+          "installDate": "2025-01-15",
+          "serial": "GEN-GV80-24-0234",
+          "installer": "지점B"
+        }
       ]
     },
     "rental": []
@@ -356,15 +649,30 @@
       "vin": "KMHAB51DBMU123458",
       "registrationDate": "2025-02-20",
       "registrationStatus": "보험등록 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "장비설치대기",
       "installer": "",
       "deviceSerial": "",
       "memo": "장비 설치 일정 조율 중",
-      "diagnosticCodes": { "category1": 3, "category2": 0, "category3": 2, "category4": 4 },
+      "diagnosticCodes": {
+        "category1": 3,
+        "category2": 0,
+        "category3": 2,
+        "category4": 4
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2026-02-20",
       "insuranceHistory": [
-        { "type": "등록", "date": "2025-02-20", "company": "렌터카공제", "product": "", "startDate": "2025-02-20", "expiryDate": "2026-02-20", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2025-02-20",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2025-02-20",
+          "expiryDate": "2026-02-20",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": []
     },
@@ -388,14 +696,35 @@
       "deviceInstallDate": "2021-12-05",
       "deviceSerial": "HYU-GRAN-22-0456",
       "memo": "정기 점검 예정",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-12-05",
       "insuranceHistory": [
-        { "type": "등록", "date": "2021-12-05", "company": "렌터카공제", "product": "", "startDate": "2021-12-05", "expiryDate": "2025-12-05", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2021-12-05",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2021-12-05",
+          "expiryDate": "2025-12-05",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2021-12-05", "installDate": "2021-12-05", "serial": "HYU-GRAN-22-0456", "installer": "지점C" }
+        {
+          "type": "install",
+          "date": "2021-12-05",
+          "installDate": "2021-12-05",
+          "serial": "HYU-GRAN-22-0456",
+          "installer": "지점C"
+        }
       ]
     },
     "rental": []
@@ -417,15 +746,59 @@
       "installer": "",
       "deviceSerial": "",
       "memo": "급속충전 시설 점검",
-      "diagnosticCodes": { "category1": 2, "category2": 5, "category3": 1, "category4": 3 },
+      "diagnosticCodes": {
+        "category1": 2,
+        "category2": 5,
+        "category3": 1,
+        "category4": 3
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-06-18",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-06-18", "company": "렌터카공제", "product": "", "startDate": "2024-06-18", "expiryDate": "2025-06-18", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-06-18",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-06-18",
+          "expiryDate": "2025-06-18",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": []
     },
-    "rental": []
+    "rental": [
+      {
+        "rental_id": 100000000600,
+        "vin": "KMHAB51DBMU123460",
+        "vehicleType": "아이오닉5 2024년형",
+        "plate": "32가0567",
+        "renter_name": "최미래",
+        "contact_number": "+82-10-3333-7777",
+        "address": "서울특별시 송파구",
+        "rental_period": {
+          "start": "2025-10-05T09:00:00",
+          "end": "2025-10-12T18:00:00"
+        },
+        "insurance_name": "렌터카공제",
+        "contract_status": "예약",
+        "rental_amount": 980000,
+        "rental_location": {
+          "lat": 37.511,
+          "lng": 127.098
+        },
+        "return_location": {
+          "lat": 37.511,
+          "lng": 127.098
+        },
+        "current_location": null,
+        "engine_status": "off",
+        "restart_blocked": false,
+        "memo": "전기차 충전 안내 필요"
+      }
+    ]
   },
   "KMHAB51DBMU123461": {
     "vin": "KMHAB51DBMU123461",
@@ -445,17 +818,69 @@
       "deviceInstallDate": "2024-07-22",
       "deviceSerial": "HYU-KONA-23-0678",
       "memo": "하이브리드 시스템 점검 완료",
-      "diagnosticCodes": { "category1": 1, "category2": 0, "category3": 3, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 1,
+        "category2": 0,
+        "category3": 3,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-07-22",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-07-22", "company": "렌터카공제", "product": "", "startDate": "2024-07-22", "expiryDate": "2025-07-22", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-07-22",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2024-07-22",
+          "expiryDate": "2025-07-22",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-07-22", "installDate": "2024-07-22", "serial": "HYU-KONA-23-0678", "installer": "지점D" }
+        {
+          "type": "install",
+          "date": "2024-07-22",
+          "installDate": "2024-07-22",
+          "serial": "HYU-KONA-23-0678",
+          "installer": "지점D"
+        }
       ]
     },
-    "rental": []
+    "rental": [
+      {
+        "rental_id": 100000000610,
+        "vin": "KMHAB51DBMU123461",
+        "vehicleType": "코나 2023년형",
+        "plate": "33가0678",
+        "renter_name": "정현우",
+        "contact_number": "+82-10-5555-1212",
+        "address": "경기도 성남시 분당구",
+        "rental_period": {
+          "start": "2025-09-18T09:30:00",
+          "end": "2025-09-26T18:30:00"
+        },
+        "insurance_name": "렌터카공제",
+        "contract_status": "진행중",
+        "rental_amount": 620000,
+        "rental_location": {
+          "lat": 37.378,
+          "lng": 127.112
+        },
+        "return_location": {
+          "lat": 37.378,
+          "lng": 127.112
+        },
+        "current_location": {
+          "lat": 37.39,
+          "lng": 127.12
+        },
+        "engine_status": "on",
+        "restart_blocked": false
+      }
+    ]
   },
   "KMHAB51DBMU123462": {
     "vin": "KMHAB51DBMU123462",
@@ -475,14 +900,35 @@
       "deviceInstallDate": "2023-11-30",
       "deviceSerial": "KIA-K5-22-1234",
       "memo": "미션 오일 교체 예정",
-      "diagnosticCodes": { "category1": 0, "category2": 1, "category3": 0, "category4": 2 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 1,
+        "category3": 0,
+        "category4": 2
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-11-30",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-11-30", "company": "렌터카공제", "product": "", "startDate": "2023-11-30", "expiryDate": "2025-11-30", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-11-30",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2023-11-30",
+          "expiryDate": "2025-11-30",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2023-11-30", "installDate": "2023-11-30", "serial": "KIA-K5-22-1234", "installer": "지점E" }
+        {
+          "type": "install",
+          "date": "2023-11-30",
+          "installDate": "2023-11-30",
+          "serial": "KIA-K5-22-1234",
+          "installer": "지점E"
+        }
       ]
     },
     "rental": []
@@ -504,11 +950,26 @@
       "installer": "",
       "deviceSerial": "",
       "memo": "변속기 점검 의뢰",
-      "diagnosticCodes": { "category1": 7, "category2": 8, "category3": 6, "category4": 5 },
+      "diagnosticCodes": {
+        "category1": 7,
+        "category2": 8,
+        "category3": 6,
+        "category4": 5
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-12-15",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-12-15", "company": "렌터카공제", "product": "", "startDate": "2023-12-15", "expiryDate": "2025-12-15", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-12-15",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2023-12-15",
+          "expiryDate": "2025-12-15",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": []
     },
@@ -532,14 +993,35 @@
       "deviceInstallDate": "2021-08-30",
       "deviceSerial": "KIA-SPTG-22-3456",
       "memo": "도난 의심 차량 - 추적 중",
-      "diagnosticCodes": { "category1": 10, "category2": 9, "category3": 8, "category4": 7 },
+      "diagnosticCodes": {
+        "category1": 10,
+        "category2": 9,
+        "category3": 8,
+        "category4": 7
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-08-30",
       "insuranceHistory": [
-        { "type": "등록", "date": "2021-08-30", "company": "렌터카공제", "product": "", "startDate": "2021-08-30", "expiryDate": "2025-08-30", "specialTerms": "", "docName": "", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2021-08-30",
+          "company": "렌터카공제",
+          "product": "",
+          "startDate": "2021-08-30",
+          "expiryDate": "2025-08-30",
+          "specialTerms": "",
+          "docName": "",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2021-08-30", "installDate": "2021-08-30", "serial": "KIA-SPTG-22-3456", "installer": "지점F" }
+        {
+          "type": "install",
+          "date": "2021-08-30",
+          "installDate": "2021-08-30",
+          "serial": "KIA-SPTG-22-3456",
+          "installer": "지점F"
+        }
       ]
     },
     "rental": []
@@ -557,19 +1039,40 @@
       "vin": "KMHPROMO000000001",
       "registrationDate": "2024-12-31",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "대기중",
       "installer": "홍길동",
       "deviceInstallDate": "2024-12-31",
       "deviceSerial": "TEST-0098-SN",
-      "memo": "데모 보험 등록 데이터",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "memo": "데모 보험 등록 데이터 - 대기중",
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2024",
       "insuranceExpiryDate": "2025-12-31",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-12-31", "company": "렌터카공제", "product": "자동차종합보험(개인용)", "startDate": "2024-12-31", "expiryDate": "2025-12-31", "specialTerms": "", "docName": "policy_VH-0098_2024.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-12-31",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-12-31",
+          "expiryDate": "2025-12-31",
+          "specialTerms": "",
+          "docName": "policy_VH-0098_2024.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-12-31", "installDate": "2024-12-31", "serial": "TEST-0098-SN", "installer": "홍길동" }
+        {
+          "type": "install",
+          "date": "2024-12-31",
+          "installDate": "2024-12-31",
+          "serial": "TEST-0098-SN",
+          "installer": "홍길동"
+        }
       ]
     },
     "rental": []
@@ -592,15 +1095,19 @@
       "deviceInstallDate": "",
       "deviceSerial": "",
       "memo": "보험 미등록 케이스",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "",
       "insuranceExpiryDate": "",
       "insuranceHistory": [],
       "deviceHistory": []
     },
     "rental": []
-  }
-  ,
+  },
   "KMHVARIETY0000001": {
     "vin": "KMHVARIETY0000001",
     "asset": {
@@ -619,17 +1126,69 @@
       "deviceInstallDate": "2025-01-16",
       "deviceSerial": "HYU-SONA-21-1000",
       "memo": "보험 만료 임박 케이스",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 1 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 1
+      },
       "insuranceInfo": "렌터카공제 2025",
       "insuranceExpiryDate": "2025-10-02",
       "insuranceHistory": [
-        { "type": "등록", "date": "2025-01-15", "company": "렌터카공제", "product": "자동차종합보험(개인용)", "startDate": "2025-01-15", "expiryDate": "2025-10-02", "specialTerms": "", "docName": "policy_VH-0100_2025.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2025-01-15",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2025-01-15",
+          "expiryDate": "2025-10-02",
+          "specialTerms": "",
+          "docName": "policy_VH-0100_2025.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2025-01-16", "installDate": "2025-01-16", "serial": "HYU-SONA-21-1000", "installer": "정우성" }
+        {
+          "type": "install",
+          "date": "2025-01-16",
+          "installDate": "2025-01-16",
+          "serial": "HYU-SONA-21-1000",
+          "installer": "정우성"
+        }
       ]
     },
-    "rental": []
+    "rental": [
+      {
+        "rental_id": 100000000620,
+        "vin": "KMHVARIETY0000001",
+        "vehicleType": "쏘나타 2021년형",
+        "plate": "11가1000",
+        "renter_name": "이현재",
+        "contact_number": "+82-10-8888-9999",
+        "address": "서울특별시 마포구",
+        "rental_period": {
+          "start": "2025-09-16T09:00:00",
+          "end": "2025-09-24T18:00:00"
+        },
+        "insurance_name": "렌터카공제",
+        "contract_status": "진행중",
+        "rental_amount": 540000,
+        "rental_location": {
+          "lat": 37.56,
+          "lng": 126.94
+        },
+        "return_location": {
+          "lat": 37.56,
+          "lng": 126.94
+        },
+        "current_location": {
+          "lat": 37.565,
+          "lng": 126.95
+        },
+        "engine_status": "on",
+        "restart_blocked": false
+      }
+    ]
   },
   "KMHVARIETY0000002": {
     "vin": "KMHVARIETY0000002",
@@ -649,12 +1208,37 @@
       "deviceInstallDate": "",
       "deviceSerial": "",
       "memo": "보험 만료(과거) + 장비 미부착",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "렌터카공제 2023",
       "insuranceExpiryDate": "2024-12-31",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-01-01", "company": "렌터카공제", "product": "자동차종합보험(개인용)", "startDate": "2023-01-01", "expiryDate": "2023-12-31", "specialTerms": "", "docName": "policy_VH-0101_2023.pdf", "docDataUrl": "" },
-        { "type": "갱신", "date": "2024-01-01", "company": "렌터카공제", "product": "자동차종합보험(개인용)", "startDate": "2024-01-01", "expiryDate": "2024-12-31", "specialTerms": "", "docName": "policy_VH-0101_2024.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-01-01",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2023-01-01",
+          "expiryDate": "2023-12-31",
+          "specialTerms": "",
+          "docName": "policy_VH-0101_2023.pdf",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2024-01-01",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-01-01",
+          "expiryDate": "2024-12-31",
+          "specialTerms": "",
+          "docName": "policy_VH-0101_2024.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": []
     },
@@ -673,17 +1257,51 @@
       "vin": "KMHVARIETY0000003",
       "registrationDate": "2024-05-10",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "도난",
       "installer": "김기사",
       "deviceInstallDate": "2024-05-11",
       "deviceSerial": "HYU-GRAN-22-1002",
-      "memo": "보험 미등록 + 도난 신고",
-      "diagnosticCodes": { "category1": 1, "category2": 0, "category3": 0, "category4": 0 },
-      "insuranceInfo": "",
-      "insuranceExpiryDate": "",
-      "insuranceHistory": [],
+      "memo": "도난 신고 접수 - 보험사 공조 진행",
+      "diagnosticCodes": {
+        "category1": 1,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
+      "insuranceInfo": "렌터카공제 2025",
+      "insuranceExpiryDate": "2025-12-31",
+      "insuranceHistory": [
+        {
+          "type": "등록",
+          "date": "2024-01-10",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-01-10",
+          "expiryDate": "2025-01-09",
+          "specialTerms": "",
+          "docName": "policy_VH-0102_2024.pdf",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-01-10",
+          "company": "렌터카공제",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2025-01-10",
+          "expiryDate": "2025-12-31",
+          "specialTerms": "",
+          "docName": "policy_VH-0102_2025.pdf",
+          "docDataUrl": ""
+        }
+      ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-05-11", "installDate": "2024-05-11", "serial": "HYU-GRAN-22-1002", "installer": "김기사" }
+        {
+          "type": "install",
+          "date": "2024-05-11",
+          "installDate": "2024-05-11",
+          "serial": "HYU-GRAN-22-1002",
+          "installer": "김기사"
+        }
       ]
     },
     "rental": [
@@ -695,14 +1313,28 @@
         "renter_name": "이의뢰",
         "contact_number": "+82-10-1111-1111",
         "address": "서울시 종로구",
-        "rental_period": { "start": "2025-09-15T09:00:00", "end": "2025-09-20T18:00:00" },
-        "insurance_name": "현대해상",
-        "rental_location": { "lat": 37.57, "lng": 126.98 },
-        "return_location": { "lat": 37.57, "lng": 126.98 },
-        "current_location": { "lat": 37.58, "lng": 126.99 },
+        "rental_period": {
+          "start": "2025-09-15T09:00:00",
+          "end": "2025-09-20T18:00:00"
+        },
+        "insurance_name": "렌터카공제",
+        "rental_location": {
+          "lat": 37.57,
+          "lng": 126.98
+        },
+        "return_location": {
+          "lat": 37.57,
+          "lng": 126.98
+        },
+        "current_location": {
+          "lat": 37.58,
+          "lng": 126.99
+        },
         "engine_status": "off",
         "restart_blocked": true,
-        "reported_stolen": true
+        "reported_stolen": true,
+        "contract_status": "반납지연",
+        "memo": "도난 신고 접수 (경찰 수사 협조중)"
       }
     ]
   },
@@ -724,15 +1356,46 @@
       "deviceInstallDate": "2024-03-21",
       "deviceSerial": "KIA-SPTG-21-1003",
       "memo": "반납 지연 + 사고 접수",
-      "diagnosticCodes": { "category1": 3, "category2": 2, "category3": 1, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 3,
+        "category2": 2,
+        "category3": 1,
+        "category4": 0
+      },
       "insuranceInfo": "DB손해보험",
       "insuranceExpiryDate": "2026-03-20",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-03-20", "company": "DB손해보험", "product": "자동차종합보험(개인용)", "startDate": "2024-03-20", "expiryDate": "2025-03-20", "specialTerms": "", "docName": "policy_VH-0103_2024.pdf", "docDataUrl": "" },
-        { "type": "갱신", "date": "2025-03-20", "company": "DB손해보험", "product": "자동차종합보험(개인용)", "startDate": "2025-03-20", "expiryDate": "2026-03-20", "specialTerms": "", "docName": "policy_VH-0103_2025.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-03-20",
+          "company": "DB손해보험",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-03-20",
+          "expiryDate": "2025-03-20",
+          "specialTerms": "",
+          "docName": "policy_VH-0103_2024.pdf",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-03-20",
+          "company": "DB손해보험",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2025-03-20",
+          "expiryDate": "2026-03-20",
+          "specialTerms": "",
+          "docName": "policy_VH-0103_2025.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2024-03-21", "installDate": "2024-03-21", "serial": "KIA-SPTG-21-1003", "installer": "박설치" }
+        {
+          "type": "install",
+          "date": "2024-03-21",
+          "installDate": "2024-03-21",
+          "serial": "KIA-SPTG-21-1003",
+          "installer": "박설치"
+        }
       ]
     },
     "rental": [
@@ -744,11 +1407,23 @@
         "renter_name": "박대여",
         "contact_number": "+82-10-2222-2222",
         "address": "부산광역시",
-        "rental_period": { "start": "2025-09-05T09:00:00", "end": "2025-09-17T18:00:00" },
+        "rental_period": {
+          "start": "2025-09-05T09:00:00",
+          "end": "2025-09-25T18:00:00"
+        },
         "insurance_name": "메리츠화재",
-        "rental_location": { "lat": 35.18, "lng": 129.07 },
-        "return_location": { "lat": 35.18, "lng": 129.07 },
-        "current_location": { "lat": 35.19, "lng": 129.08 },
+        "rental_location": {
+          "lat": 35.18,
+          "lng": 129.07
+        },
+        "return_location": {
+          "lat": 35.18,
+          "lng": 129.07
+        },
+        "current_location": {
+          "lat": 35.19,
+          "lng": 129.08
+        },
         "engine_status": "on",
         "restart_blocked": false,
         "accident_reported": true,
@@ -761,9 +1436,10 @@
           "accidentDateTime": "2025-09-20T16:45:30",
           "accidentDisplayTime": "2025.09.20 16:45:30",
           "blackboxFile": null,
-          "blackboxFileName": "",
+          "blackboxFileName": "accident_VH-0103_20250920.mp4",
           "recordedAt": "2025-09-20T17:00:00.000Z"
-        }
+        },
+        "contract_status": "진행중"
       }
     ]
   },
@@ -780,20 +1456,51 @@
       "vin": "KMHVARIETY0000005",
       "registrationDate": "2023-09-01",
       "registrationStatus": "장비부착 완료",
-      "vehicleStatus": "운행중",
+      "vehicleStatus": "대기중",
       "installer": "",
       "deviceInstallDate": "2023-09-01",
       "deviceSerial": "HYU-AVAN-20-1004",
       "memo": "top-level 보험 정보 비워두고 이력으로 유도",
-      "diagnosticCodes": { "category1": 0, "category2": 1, "category3": 0, "category4": 0 },
-      "insuranceInfo": "",
-      "insuranceExpiryDate": "",
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 1,
+        "category3": 0,
+        "category4": 0
+      },
+      "insuranceInfo": "삼성화재 2025",
+      "insuranceExpiryDate": "2025-09-01",
       "insuranceHistory": [
-        { "type": "등록", "date": "2023-09-01", "company": "삼성화재", "product": "자동차종합보험(개인용)", "startDate": "2023-09-01", "expiryDate": "2024-09-01", "specialTerms": "", "docName": "policy_VH-0104_2023.pdf", "docDataUrl": "" },
-        { "type": "갱신", "date": "2024-09-01", "company": "삼성화재", "product": "자동차종합보험(개인용)", "startDate": "2024-09-01", "expiryDate": "2025-09-01", "specialTerms": "", "docName": "policy_VH-0104_2024.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2023-09-01",
+          "company": "삼성화재",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2023-09-01",
+          "expiryDate": "2024-09-01",
+          "specialTerms": "",
+          "docName": "policy_VH-0104_2023.pdf",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2024-09-01",
+          "company": "삼성화재",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-09-01",
+          "expiryDate": "2025-09-01",
+          "specialTerms": "",
+          "docName": "policy_VH-0104_2024.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": [
-        { "type": "install", "date": "2023-09-01", "installDate": "2023-09-01", "serial": "HYU-AVAN-20-1004", "installer": "" }
+        {
+          "type": "install",
+          "date": "2023-09-01",
+          "installDate": "2023-09-01",
+          "serial": "HYU-AVAN-20-1004",
+          "installer": ""
+        }
       ]
     },
     "rental": []
@@ -811,17 +1518,42 @@
       "vin": "KMHVARIETY0000006",
       "registrationDate": "2022-11-11",
       "registrationStatus": "보험등록 완료",
-      "vehicleStatus": "대기중",
+      "vehicleStatus": "운행중",
       "installer": "",
       "deviceInstallDate": "",
       "deviceSerial": "",
       "memo": "렌탈 다건 케이스(과거+현재)",
-      "diagnosticCodes": { "category1": 0, "category2": 0, "category3": 0, "category4": 0 },
+      "diagnosticCodes": {
+        "category1": 0,
+        "category2": 0,
+        "category3": 0,
+        "category4": 0
+      },
       "insuranceInfo": "한화손해보험",
       "insuranceExpiryDate": "2026-11-11",
       "insuranceHistory": [
-        { "type": "등록", "date": "2024-11-11", "company": "한화손해보험", "product": "자동차종합보험(개인용)", "startDate": "2024-11-11", "expiryDate": "2025-11-11", "specialTerms": "", "docName": "policy_VH-0105_2024.pdf", "docDataUrl": "" },
-        { "type": "갱신", "date": "2025-11-11", "company": "한화손해보험", "product": "자동차종합보험(개인용)", "startDate": "2025-11-11", "expiryDate": "2026-11-11", "specialTerms": "", "docName": "policy_VH-0105_2025.pdf", "docDataUrl": "" }
+        {
+          "type": "등록",
+          "date": "2024-11-11",
+          "company": "한화손해보험",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2024-11-11",
+          "expiryDate": "2025-11-11",
+          "specialTerms": "",
+          "docName": "policy_VH-0105_2024.pdf",
+          "docDataUrl": ""
+        },
+        {
+          "type": "갱신",
+          "date": "2025-11-11",
+          "company": "한화손해보험",
+          "product": "자동차종합보험(개인용)",
+          "startDate": "2025-11-11",
+          "expiryDate": "2026-11-11",
+          "specialTerms": "",
+          "docName": "policy_VH-0105_2025.pdf",
+          "docDataUrl": ""
+        }
       ],
       "deviceHistory": []
     },
@@ -834,13 +1566,24 @@
         "renter_name": "신과거",
         "contact_number": "+82-10-3333-3333",
         "address": "대전광역시",
-        "rental_period": { "start": "2024-03-01T09:00:00", "end": "2024-03-10T18:00:00" },
+        "rental_period": {
+          "start": "2024-03-01T09:00:00",
+          "end": "2024-03-10T18:00:00"
+        },
         "insurance_name": "한화손해보험",
-        "rental_location": { "lat": 36.35, "lng": 127.38 },
-        "return_location": { "lat": 36.35, "lng": 127.38 },
+        "rental_location": {
+          "lat": 36.35,
+          "lng": 127.38
+        },
+        "return_location": {
+          "lat": 36.35,
+          "lng": 127.38
+        },
         "current_location": null,
         "engine_status": "off",
-        "restart_blocked": false
+        "restart_blocked": false,
+        "contract_status": "완료",
+        "return_confirmed": true
       },
       {
         "rental_id": 100000001011,
@@ -850,13 +1593,27 @@
         "renter_name": "유현재",
         "contact_number": "+82-10-4444-4444",
         "address": "광주광역시",
-        "rental_period": { "start": "2025-09-22T09:00:00", "end": "2025-10-02T18:00:00" },
+        "rental_period": {
+          "start": "2025-09-22T09:00:00",
+          "end": "2025-10-02T18:00:00"
+        },
         "insurance_name": "한화손해보험",
-        "rental_location": { "lat": 35.15, "lng": 126.85 },
-        "return_location": { "lat": 35.15, "lng": 126.85 },
-        "current_location": { "lat": 35.16, "lng": 126.86 },
+        "rental_location": {
+          "lat": 35.15,
+          "lng": 126.85
+        },
+        "return_location": {
+          "lat": 35.15,
+          "lng": 126.85
+        },
+        "current_location": {
+          "lat": 35.16,
+          "lng": 126.86
+        },
         "engine_status": "on",
-        "restart_blocked": false
+        "restart_blocked": false,
+        "contract_status": "진행중",
+        "rental_amount": 720000
       }
     ]
   }


### PR DESCRIPTION
## Summary
- overhaul the seed rental data to remove contradictory scenarios and add realistic contract statuses
- align vehicle statuses with rental timelines and ensure insurance is present for all active contracts
- add representative edge cases such as overdue, stolen, reserved, and maintenance states for easier QA
- ensure the seeded accident case references the bundled dashcam mp4 so the modal can play the footage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d133c284108332aa2355deefad8a77