### PR TITLE
Add sorting controls to asset and rental management tables

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,35 @@
     font-weight: 600;
 }
 
+.asset-table thead th .table-sort-button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.asset-table thead th .table-sort-button:focus-visible {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+}
+
+.asset-table thead th .table-sort-icon {
+    display: inline-flex;
+    align-items: center;
+    color: #9e9e9e;
+}
+
+.asset-table thead th .table-sort-button.is-active .table-sort-icon {
+    color: #1976d2;
+}
+
 /* Asset/toolbars: align controls consistently */
 .asset-toolbar {
     display: flex;

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { FaSort, FaSortDown, FaSortUp } from "react-icons/fa";
 import { DIMENSIONS } from "../constants";
+import { compareValues } from "../utils/sort";
 
 export default function Table({
     columns,
@@ -12,6 +14,43 @@ export default function Table({
 }) {
     const { selected, toggleSelect, toggleSelectAllVisible, allVisibleSelected } = selection || {};
     const hasSelection = !!selection;
+    const [sortConfig, setSortConfig] = useState(null);
+
+    useEffect(() => {
+        if (sortConfig && !columns.some((col) => col.key === sortConfig.key && col.sortable)) {
+            setSortConfig(null);
+        }
+    }, [columns, sortConfig]);
+
+    const sortedData = useMemo(() => {
+        if (!sortConfig) return data;
+        const column = columns.find((col) => col.key === sortConfig.key && col.sortable);
+        if (!column) return data;
+        const accessor = column.sortAccessor || ((row) => row[column.key]);
+        const sortType = column.sortType || "string";
+        const items = [...data];
+        items.sort((a, b) => {
+            const aValue = accessor(a);
+            const bValue = accessor(b);
+            return compareValues(aValue, bValue, sortType, sortConfig.direction);
+        });
+        return items;
+    }, [data, columns, sortConfig]);
+
+    const handleSort = (column) => {
+        if (!column.sortable) return;
+        setSortConfig((prev) => {
+            if (prev?.key === column.key) {
+                if (prev.direction === "asc") {
+                    return { key: column.key, direction: "desc" };
+                }
+                if (prev.direction === "desc") {
+                    return null;
+                }
+            }
+            return { key: column.key, direction: "asc" };
+        });
+    };
 
     return (
         <div className="table-wrap">
@@ -20,28 +59,47 @@ export default function Table({
                     <tr>
                         {hasSelection && (
                             <th style={{ width: DIMENSIONS.ICON_SIZE_LG, textAlign: "center" }}>
-                                <input 
-                                    type="checkbox" 
+                                <input
+                                    type="checkbox"
                                     aria-label="현재 목록 전체 선택" 
                                     checked={allVisibleSelected} 
                                     onChange={toggleSelectAllVisible} 
                                 />
                             </th>
                         )}
-                        {columns.map((col) => (
-                            <th key={col.key} style={col.style}>
-                                {col.label}
-                            </th>
-                        ))}
+                        {columns.map((col) => {
+                            const isSorted = sortConfig?.key === col.key;
+                            const sortDirection = isSorted ? sortConfig.direction : null;
+                            const ariaSort = col.sortable ? (sortDirection === "asc" ? "ascending" : sortDirection === "desc" ? "descending" : "none") : undefined;
+
+                            return (
+                                <th key={col.key} style={col.style} aria-sort={ariaSort}>
+                                    {col.sortable ? (
+                                        <button
+                                            type="button"
+                                            className={`table-sort-button${isSorted ? " is-active" : ""}`}
+                                            onClick={() => handleSort(col)}
+                                        >
+                                            <span>{col.label}</span>
+                                            <span className="table-sort-icon" aria-hidden="true">
+                                                {isSorted ? (sortDirection === "asc" ? <FaSortUp /> : <FaSortDown />) : <FaSort />}
+                                            </span>
+                                        </button>
+                                    ) : (
+                                        col.label
+                                    )}
+                                </th>
+                            );
+                        })}
                     </tr>
                 </thead>
                 <tbody>
-                    {data.map((row, index) => (
+                    {sortedData.map((row, index) => (
                         <tr key={row.id || index}>
                             {hasSelection && (
                                 <td style={{ textAlign: "center" }}>
-                                    <input 
-                                        type="checkbox" 
+                                    <input
+                                        type="checkbox"
                                         aria-label={`선택: ${row.plate || row.id}`} 
                                         checked={selected.has(row.id)} 
                                         onChange={() => toggleSelect(row.id)} 

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -1,0 +1,101 @@
+const collator = new Intl.Collator("ko", { numeric: true, sensitivity: "base" });
+
+const toNumber = (value) => {
+    if (typeof value === "number") {
+        return Number.isNaN(value) ? null : value;
+    }
+    if (typeof value === "boolean") {
+        return value ? 1 : 0;
+    }
+    if (typeof value === "string") {
+        const normalized = value.replace(/,/g, "").trim();
+        if (normalized === "") return null;
+        const parsed = Number(normalized);
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.getTime();
+    }
+    return null;
+};
+
+const toTimestamp = (value) => {
+    if (value instanceof Date) {
+        const timestamp = value.getTime();
+        return Number.isNaN(timestamp) ? null : timestamp;
+    }
+    if (typeof value === "number") {
+        return Number.isNaN(value) ? null : value;
+    }
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed === "") return null;
+        const timestamp = Date.parse(trimmed);
+        return Number.isNaN(timestamp) ? null : timestamp;
+    }
+    return null;
+};
+
+const toBoolean = (value) => {
+    if (value === null || value === undefined) return null;
+    return Boolean(value);
+};
+
+/**
+ * Compare two values by sort type and direction.
+ * @param {*} aValue
+ * @param {*} bValue
+ * @param {"string"|"number"|"date"|"boolean"} sortType
+ * @param {"asc"|"desc"} direction
+ * @returns {number}
+ */
+export const compareValues = (aValue, bValue, sortType = "string", direction = "asc") => {
+    const dir = direction === "desc" ? -1 : 1;
+    const aIsNull = aValue === null || aValue === undefined;
+    const bIsNull = bValue === null || bValue === undefined;
+
+    if (aIsNull && bIsNull) return 0;
+    if (aIsNull) return 1 * dir;
+    if (bIsNull) return -1 * dir;
+
+    switch (sortType) {
+        case "number": {
+            const aNum = toNumber(aValue);
+            const bNum = toNumber(bValue);
+            const aNumIsNull = aNum === null || Number.isNaN(aNum);
+            const bNumIsNull = bNum === null || Number.isNaN(bNum);
+            if (aNumIsNull && bNumIsNull) return 0;
+            if (aNumIsNull) return 1 * dir;
+            if (bNumIsNull) return -1 * dir;
+            if (aNum === bNum) return 0;
+            return aNum > bNum ? 1 * dir : -1 * dir;
+        }
+        case "date": {
+            const aTime = toTimestamp(aValue);
+            const bTime = toTimestamp(bValue);
+            const aTimeIsNull = aTime === null || Number.isNaN(aTime);
+            const bTimeIsNull = bTime === null || Number.isNaN(bTime);
+            if (aTimeIsNull && bTimeIsNull) return 0;
+            if (aTimeIsNull) return 1 * dir;
+            if (bTimeIsNull) return -1 * dir;
+            if (aTime === bTime) return 0;
+            return aTime > bTime ? 1 * dir : -1 * dir;
+        }
+        case "boolean": {
+            const aBool = toBoolean(aValue);
+            const bBool = toBoolean(bValue);
+            const aBoolIsNull = aBool === null;
+            const bBoolIsNull = bBool === null;
+            if (aBoolIsNull && bBoolIsNull) return 0;
+            if (aBoolIsNull) return 1 * dir;
+            if (bBoolIsNull) return -1 * dir;
+            if (aBool === bBool) return 0;
+            return aBool ? 1 * dir : -1 * dir;
+        }
+        default: {
+            const comparison = collator.compare(String(aValue), String(bValue));
+            return comparison * dir;
+        }
+    }
+};
+


### PR DESCRIPTION
## Summary
- add a reusable comparator helper for table sorting
- enable sortable table headers and styling across the app
- wire up asset and rental management pages to supply sort metadata for columns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d148176b388332923ac2c08c8b3fe5