### PR TITLE
feat: add CI upload modal (image preview + actions)

### DIFF
--- a/src/components/CiUploadModal.css
+++ b/src/components/CiUploadModal.css
@@ -1,0 +1,105 @@
+.ci-upload-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.ci-upload-modal__content {
+  background: #fff;
+  width: 100%;
+  max-width: 520px;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ci-upload-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #ececec;
+}
+
+.ci-upload-modal__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.ci-upload-modal__close {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ci-upload-modal__body {
+  padding: 16px;
+}
+
+.ci-upload-modal__preview {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #fafafa;
+  border: 1px dashed #d9d9d9;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.ci-upload-modal__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.ci-upload-modal__placeholder {
+  color: #909090;
+  font-size: 14px;
+}
+
+.ci-upload-modal__controls {
+  margin-top: 12px;
+}
+
+.ci-upload-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #ececec;
+}
+
+.ci-upload-modal__button {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.ci-upload-modal__button--secondary {
+  background: #fff;
+  border-color: #dcdcdc;
+}
+
+.ci-upload-modal__button--primary {
+  background: #2b6cb0;
+  color: #fff;
+}
+
+.ci-upload-modal__button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+

--- a/src/components/CiUploadModal.jsx
+++ b/src/components/CiUploadModal.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from "react";
+import "./CiUploadModal.css";
+
+function CiUploadModal({ isOpen, onClose, onSubmit, title = "CI 이미지 업로드" }) {
+  const fileInputRef = useRef(null);
+  const [file, setFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFile(null);
+      setPreviewUrl("");
+    }
+  }, [isOpen]);
+
+  const handleFileChange = (e) => {
+    const selected = e.target.files && e.target.files[0];
+    if (!selected) return;
+    setFile(selected);
+
+    const reader = new FileReader();
+    reader.onload = (ev) => setPreviewUrl(String(ev.target?.result || ""));
+    reader.readAsDataURL(selected);
+  };
+
+  const handleRegister = () => {
+    if (file) {
+      onSubmit && onSubmit(file, previewUrl);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="ci-upload-modal__overlay" role="dialog" aria-modal="true">
+      <div className="ci-upload-modal__content">
+        <div className="ci-upload-modal__header">
+          <h3 className="ci-upload-modal__title">{title}</h3>
+          <button className="ci-upload-modal__close" aria-label="닫기" onClick={onClose}>
+            ×
+          </button>
+        </div>
+        <div className="ci-upload-modal__body">
+          <div className="ci-upload-modal__preview">
+            {previewUrl ? (
+              <img src={previewUrl} alt="CI 미리보기" className="ci-upload-modal__image" />
+            ) : (
+              <div className="ci-upload-modal__placeholder">미리보기가 여기에 표시됩니다</div>
+            )}
+          </div>
+          <div className="ci-upload-modal__controls">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+            />
+          </div>
+        </div>
+        <div className="ci-upload-modal__footer">
+          <button className="ci-upload-modal__button ci-upload-modal__button--secondary" onClick={onClose}>
+            취소
+          </button>
+          <button
+            className="ci-upload-modal__button ci-upload-modal__button--primary"
+            onClick={handleRegister}
+            disabled={!file}
+          >
+            등록하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CiUploadModal;


### PR DESCRIPTION
### Summary
- Adds reusable CI upload-and-preview modal with cancel/register buttons.
- Includes file input, live preview, and disabled register until file selected.

### Changes
- New: `src/components/CiUploadModal.jsx`
- New: `src/components/CiUploadModal.css`

### Notes
- Not yet wired to `NavigationBar` click; can integrate by opening modal instead of direct file dialog when no CI image. I can push that wiring as a follow-up commit to this branch if you want.

### Testing
- Component compiles with Vite; no integration in UI yet.
- To try locally, import `CiUploadModal` in any page and toggle `isOpen`.

### Checklist
- [x] Conventional Commit message
- [x] Scoped CSS
- [x] No API or route changes
