### PR TITLE
feat/sort toggle table

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,7 @@
 .asset-table thead th {
     background: #fafafa;
     font-weight: 600;
+    vertical-align: middle;
 }
 
 /* Sorting controls in table headers */
@@ -39,7 +40,8 @@
     white-space: nowrap;
 }
 .asset-table thead th .th-label {
-    vertical-align: middle;
+    display: inline-flex;
+    align-items: center;
 }
 .asset-table thead th .sort-toggle {
     border: 0;
@@ -48,13 +50,14 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin-left: 6px;
-    padding: 2px 2px;
+    margin-left: 4px;
+    padding: 0;
     cursor: pointer;
+    vertical-align: middle;
 }
 .asset-table thead th .sort-toggle .tri {
-    font-size: 0.7rem;
-    line-height: 0.7rem;
+    font-size: 0.6rem;
+    line-height: 0.6rem;
     color: #bbb;
 }
 .asset-table thead th .sort-toggle:hover .tri {
@@ -650,26 +653,99 @@ body {
     text-align: center;
 }
 
-/* Asset dialog layout (screenshot-based skeleton) */
-.asset-dialog { padding-bottom: 8px; }
-.asset-dialog__grid { display: grid; grid-template-columns: 280px 1fr; gap: 16px; align-items: start; max-width: 800px; }
-.asset-dialog__left { display: grid; gap: 12px; }
-.asset-doc { background: #fff; border: 1px solid #eee; border-radius: 8px; padding: 10px; }
-.asset-doc__title { font-size: 0.95rem; font-weight: 600; margin-bottom: 8px; }
-.asset-doc__box { border: 1px dashed #cfd8dc; border-radius: 8px; height: 80px; display: flex; align-items: center; justify-content: center; background: #fafbfc; }
-.asset-doc__placeholder { color: #90a4ae; font-size: 0.9rem; }
+/* Asset dialog layout - insurance dialog style */
+.asset-dialog {
+    padding-bottom: 8px;
+}
 
-.asset-dialog__right { display: grid; gap: 16px; }
-.asset-info { grid-template-columns: 140px 1fr; }
-.asset-info__label { color: #555; }
-.asset-info__value { color: #222; font-weight: 600; }
+.asset-dialog__body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
 
-.asset-dates { display: flex; flex-direction: column; gap: 8px; }
-.asset-dates__item { background: #fff; border: 1px solid #eee; border-radius: 8px; padding: 10px; }
-.asset-dates__label { color: #666; font-size: 0.85rem; margin-bottom: 4px; }
-.asset-dates__value { font-weight: 600; font-size: 0.95rem; }
+.asset-docs-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
 
-.asset-dialog__footer { margin-top: 12px; display: flex; justify-content: flex-end; }
+@media (max-width: 768px) {
+    .asset-docs-section {
+        grid-template-columns: 1fr;
+    }
+}
+
+.asset-doc {
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.asset-doc__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.asset-doc__box {
+    border: 1px dashed #cfd8dc;
+    border-radius: 8px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fafbfc;
+}
+
+.asset-doc__placeholder {
+    color: #90a4ae;
+    font-size: 0.9rem;
+}
+
+.asset-info {
+    grid-template-columns: 140px 1fr;
+}
+
+.asset-info__label {
+    color: #555;
+}
+
+.asset-info__value {
+    color: #222;
+    font-weight: 600;
+}
+
+.asset-dates {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.asset-dates__item {
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    padding: 8px 10px;
+}
+
+.asset-dates__label {
+    color: #666;
+    font-size: 0.85rem;
+    margin-bottom: 2px;
+}
+
+.asset-dates__value {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.asset-dialog__footer {
+    margin-top: 12px;
+    display: flex;
+    justify-content: flex-end;
+}
 
 @media (max-width: 960px) {
   .asset-dialog__grid { grid-template-columns: 1fr; }

--- a/src/App.css
+++ b/src/App.css
@@ -747,8 +747,11 @@ body {
     justify-content: flex-end;
 }
 
-@media (max-width: 960px) {
-  .asset-dialog__grid { grid-template-columns: 1fr; }
+.asset-history__item {
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    padding: 8px 10px;
 }
 
 .asset-bottom-row { display: grid; grid-template-columns: 140px 1fr; align-items: center; }

--- a/src/components/AssetDialog.jsx
+++ b/src/components/AssetDialog.jsx
@@ -65,8 +65,8 @@ export default function AssetDialog({ asset = {}, mode = "create", onClose, onSu
 
   return (
     <div className="asset-dialog">
-      <div className="asset-dialog__grid">
-        <div className="asset-dialog__left">
+      <div className="asset-dialog__body">
+        <div className="asset-docs-section" style={{ marginBottom: 16 }}>
           {isEdit ? (
             <>
               {docBoxView("원리금 상환 계획표")}
@@ -80,40 +80,49 @@ export default function AssetDialog({ asset = {}, mode = "create", onClose, onSu
           )}
         </div>
 
-        <div className="asset-dialog__right">
-          {isEdit ? (
-            <div className="asset-info grid-info">
-              {infoRow("제조사", asset.make || "")}
-              {infoRow("차종", asset.model || "")}
-              {infoRow("차량번호", asset.plate || "")}
-              {infoRow("차대번호(VIN)", asset.vin || "")}
-              {infoRow("차량가액", asset.vehicleValue || "")}
-            </div>
-          ) : (
-            <div className="asset-info grid-info">
-              <div className="asset-info__label">제조사</div>
-              <input className="form-input" value={form.make} onChange={(e) => setForm((p) => ({ ...p, make: e.target.value }))} placeholder="예: 현대" />
-
-              <div className="asset-info__label">차종</div>
-              <input className="form-input" value={form.model} onChange={(e) => setForm((p) => ({ ...p, model: e.target.value }))} placeholder="예: 쏘나타" />
-
-              <div className="asset-info__label">차량번호</div>
-              <input className="form-input" value={form.plate} onChange={(e) => setForm((p) => ({ ...p, plate: e.target.value }))} placeholder="예: 28가2345" />
-
-              <div className="asset-info__label">차대번호(VIN)</div>
-              <input className="form-input" value={form.vin} onChange={(e) => setForm((p) => ({ ...p, vin: e.target.value }))} placeholder="예: KMHxxxxxxxxxxxxxx" />
-
-              <div className="asset-info__label">차량가액</div>
-              <input className="form-input" type="number" value={form.vehicleValue} onChange={(e) => setForm((p) => ({ ...p, vehicleValue: e.target.value }))} placeholder="예: 25000000" />
-            </div>
-          )}
-
-          <div className="asset-dates">
-            {asset.purchaseDate && dateItem("차량 구매일", asset.purchaseDate)}
-            {(asset.registrationDate || asset.systemRegDate) && dateItem("전산 등록일", asset.registrationDate || asset.systemRegDate)}
-            {asset.systemDelDate && dateItem("전산 삭제일", asset.systemDelDate)}
+        {isEdit ? (
+          <div className="asset-info grid-info">
+            {infoRow("제조사", asset.make || "")}
+            {infoRow("차종", asset.model || "")}
+            {infoRow("차량번호", asset.plate || "")}
+            {infoRow("차대번호(VIN)", asset.vin || "")}
+            {infoRow("차량가액", asset.vehicleValue || "")}
           </div>
-        </div>
+        ) : (
+          <div className="asset-info grid-info">
+            {infoRow(
+              "제조사",
+              <input className="form-input" value={form.make} onChange={(e) => setForm((p) => ({ ...p, make: e.target.value }))} placeholder="예: 현대" />
+            )}
+            {infoRow(
+              "차종",
+              <input className="form-input" value={form.model} onChange={(e) => setForm((p) => ({ ...p, model: e.target.value }))} placeholder="예: 쏘나타" />
+            )}
+            {infoRow(
+              "차량번호",
+              <input className="form-input" value={form.plate} onChange={(e) => setForm((p) => ({ ...p, plate: e.target.value }))} placeholder="예: 28가2345" />
+            )}
+            {infoRow(
+              "차대번호(VIN)",
+              <input className="form-input" value={form.vin} onChange={(e) => setForm((p) => ({ ...p, vin: e.target.value }))} placeholder="예: KMHxxxxxxxxxxxxxx" />
+            )}
+            {infoRow(
+              "차량가액",
+              <input className="form-input" type="number" value={form.vehicleValue} onChange={(e) => setForm((p) => ({ ...p, vehicleValue: e.target.value }))} placeholder="예: 25000000" />
+            )}
+          </div>
+        )}
+
+        {(asset.purchaseDate || asset.registrationDate || asset.systemRegDate || asset.systemDelDate) && (
+          <div style={{ marginTop: 16 }}>
+            <div className="asset-doc__title" style={{ marginBottom: 8 }}>등록 정보</div>
+            <div className="asset-dates">
+              {asset.purchaseDate && dateItem("차량 구매일", asset.purchaseDate)}
+              {(asset.registrationDate || asset.systemRegDate) && dateItem("전산 등록일", asset.registrationDate || asset.systemRegDate)}
+              {asset.systemDelDate && dateItem("전산 삭제일", asset.systemDelDate)}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="asset-dialog__footer">

--- a/src/components/DeviceEventLog.jsx
+++ b/src/components/DeviceEventLog.jsx
@@ -19,32 +19,27 @@ export default function DeviceEventLog({ assetId, fallbackInstallDate = "" }) {
   }, [assetId, fallbackInstallDate]);
 
   return (
-    <section className="card card-padding" style={{ marginTop: 12 }}>
-      <h3 className="section-title section-margin-0">단말이벤트 기록</h3>
-      <div style={{ marginTop: 8 }}>
-        {(!events || events.length === 0) && (
-          <div style={{ color: "#666", fontSize: "0.9rem" }}>기록 없음</div>
-        )}
-        {events && events.length > 0 && (
-          <div>
-            {events.map((e) => (
-              <div
-                key={e.id}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  padding: "8px 0",
-                  borderBottom: "1px solid #eee",
-                }}
-              >
-                <div style={{ fontWeight: 600 }}>{e.label || "이벤트"}</div>
-                <div style={{ marginLeft: "auto", color: "#333" }}>{e.date || "-"}</div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </section>
+    <div style={{ marginTop: 16 }}>
+      <div className="asset-doc__title" style={{ marginBottom: 6 }}>단말 이벤트 기록</div>
+      {(!events || events.length === 0) && (
+        <div style={{ color: "#666", fontSize: "0.9rem", padding: "8px 0" }}>기록 없음</div>
+      )}
+      {events && events.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {events.map((e) => (
+            <div key={e.id} className="asset-history__item">
+              <div style={{ fontSize: 12 }}>{e.label || "이벤트"} {e.date || "-"}</div>
+              {e.meta && !e.meta.virtual && (
+                <div style={{ fontSize: 12, color: '#666' }}>
+                  {e.meta.installer && `장착자: ${e.meta.installer}`}
+                  {e.meta.supplier && ` · 공급사: ${e.meta.supplier}`}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { DIMENSIONS } from "../constants";
 
 export default function Table({
@@ -10,6 +10,7 @@ export default function Table({
     emptyMessage = "데이터가 없습니다.",
     stickyHeader = false,
     stickyOffset = 0,
+    initialSort,
     ...props
 }) {
     const { selected, toggleSelect, toggleSelectAllVisible, allVisibleSelected } = selection || {};
@@ -30,6 +31,97 @@ export default function Table({
           }
         : undefined;
 
+    // Sorting state and helpers
+    const [sortKey, setSortKey] = useState(() => (initialSort && initialSort.key) || null);
+    const [sortDir, setSortDir] = useState(() => (initialSort && initialSort.direction) || null); // 'asc' | 'desc' | null
+
+    const getCellValue = (row, col) => {
+        if (!col) return undefined;
+        if (typeof col.sortAccessor === "function") return col.sortAccessor(row);
+        if (typeof col.accessor === "function") return col.accessor(row);
+        if (typeof col.key === "string") return row?.[col.key];
+        return undefined;
+    };
+
+    const parseMaybeDate = (val) => {
+        if (val == null) return null;
+        if (val instanceof Date && !isNaN(val)) return val;
+        if (typeof val !== "string") return null;
+        const s = val.trim();
+        if (!s) return null;
+        const iso = Date.parse(s);
+        if (!Number.isNaN(iso)) return new Date(iso);
+        return null;
+    };
+
+    const normalize = (val) => {
+        if (val == null) return { type: "empty", v: null };
+        const t = typeof val;
+        if (t === "number") return { type: "number", v: val };
+        if (t === "boolean") return { type: "number", v: val ? 1 : 0 };
+        if (val instanceof Date && !isNaN(val)) return { type: "date", v: val.getTime() };
+        if (t === "string") {
+            const asDate = parseMaybeDate(val);
+            if (asDate) return { type: "date", v: asDate.getTime() };
+            const num = Number(val);
+            if (!Number.isNaN(num) && /^-?\d+(?:\.\d+)?$/.test(val.trim())) {
+                return { type: "number", v: num };
+            }
+            return { type: "string", v: val.toLowerCase() };
+        }
+        try {
+            return { type: "string", v: String(val).toLowerCase() };
+        } catch {
+            return { type: "string", v: "" };
+        }
+    };
+
+    const sortedData = useMemo(() => {
+        if (!Array.isArray(data)) return [];
+        if (!sortKey || !sortDir) return data;
+        const col = columns.find((c) => c.key === sortKey);
+        if (!col) return data;
+        const sortable = col.sortable !== false && col.key !== "select";
+        if (!sortable) return data;
+        const withIndex = data.map((row, idx) => ({ row, idx }));
+        withIndex.sort((a, b) => {
+            const va = getCellValue(a.row, col);
+            const vb = getCellValue(b.row, col);
+            if (typeof col.sorter === "function") {
+                const cmpCustom = col.sorter(a.row, b.row, { dir: sortDir });
+                if (cmpCustom !== 0) return sortDir === "asc" ? cmpCustom : -cmpCustom;
+                return a.idx - b.idx;
+            }
+            const na = normalize(va);
+            const nb = normalize(vb);
+            if (na.type !== nb.type) {
+                const order = { empty: 3, string: 2, number: 1, date: 1 };
+                const pa = order[na.type] ?? 2;
+                const pb = order[nb.type] ?? 2;
+                if (pa !== pb) return sortDir === "asc" ? pa - pb : pb - pa;
+            }
+            let cmp = 0;
+            if (na.v == null && nb.v != null) cmp = 1;
+            else if (na.v != null && nb.v == null) cmp = -1;
+            else if (na.v == null && nb.v == null) cmp = 0;
+            else if (na.type === "number" || na.type === "date") cmp = na.v - nb.v;
+            else if (na.type === "string") cmp = String(na.v).localeCompare(String(nb.v), undefined, { sensitivity: "base", numeric: true });
+            if (cmp === 0) return a.idx - b.idx;
+            return sortDir === "asc" ? cmp : -cmp;
+        });
+        return withIndex.map((x) => x.row);
+    }, [data, columns, sortKey, sortDir]);
+
+    const handleSortToggle = (key, col) => {
+        if (col && (col.sortable === false || key === "select")) return;
+        if (sortKey !== key) {
+            setSortKey(key);
+            setSortDir("asc");
+            return;
+        }
+        setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    };
+
     return (
         <div className={wrapClassNames.filter(Boolean).join(" ")} style={stickyStyle}>
             <table className={tableClassNames.filter(Boolean).join(" ")} {...props}>
@@ -38,30 +130,51 @@ export default function Table({
                         {hasSelection && (
                             <th style={{ width: DIMENSIONS.ICON_SIZE_LG, textAlign: "center" }}>
                                 <input
-                                    type="checkbox" 
-                                    aria-label="현재 목록 전체 선택" 
-                                    checked={allVisibleSelected} 
-                                    onChange={toggleSelectAllVisible} 
+                                    type="checkbox"
+                                    aria-label="현재 목록 전체 선택"
+                                    checked={allVisibleSelected}
+                                    onChange={toggleSelectAllVisible}
                                 />
                             </th>
                         )}
-                        {columns.map((col) => (
-                            <th key={col.key} style={col.style}>
-                                {col.label}
-                            </th>
-                        ))}
+                        {columns.map((col) => {
+                            const sortable = col.sortable !== false && col.key !== "select";
+                            const isActive = sortKey === col.key && !!sortDir;
+                            const ariaSort = isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none";
+                            return (
+                                <th key={col.key} style={col.style} aria-sort={ariaSort} className={sortable ? "th-sortable" : undefined}>
+                                    <span className="th-label">{col.label}</span>
+                                    {sortable && (
+                                        <button
+                                            type="button"
+                                            className={[
+                                                "sort-toggle",
+                                                sortKey === col.key && sortDir ? "active" : "",
+                                                sortKey === col.key && sortDir ? `dir-${sortDir}` : "",
+                                            ].filter(Boolean).join(" ")}
+                                            title={`${col.label} 정렬 토글`}
+                                            aria-label={`${col.label} 정렬 토글 (오름차순/내림차순)`}
+                                            onClick={() => handleSortToggle(col.key, col)}
+                                        >
+                                            <span className="tri up">▲</span>
+                                            <span className="tri down">▼</span>
+                                        </button>
+                                    )}
+                                </th>
+                            );
+                        })}
                     </tr>
                 </thead>
                 <tbody>
-                    {data.map((row, index) => (
-                        <tr key={row.id || index}>
+                    {sortedData.map((row, index) => (
+                        <tr key={row.id || index} onClick={onRowClick ? () => onRowClick(row) : undefined}>
                             {hasSelection && (
                                 <td style={{ textAlign: "center" }}>
-                                    <input 
-                                        type="checkbox" 
-                                        aria-label={`선택: ${row.plate || row.id}`} 
-                                        checked={selected.has(row.id)} 
-                                        onChange={() => toggleSelect(row.id)} 
+                                    <input
+                                        type="checkbox"
+                                        aria-label={`선택: ${row.plate || row.id}`}
+                                        checked={selected?.has ? selected.has(row.id) : false}
+                                        onChange={() => toggleSelect && toggleSelect(row.id)}
                                     />
                                 </td>
                             )}
@@ -74,9 +187,7 @@ export default function Table({
                     ))}
                 </tbody>
             </table>
-            {data.length === 0 && (
-                <div className="empty">{emptyMessage}</div>
-            )}
+            {data.length === 0 && <div className="empty">{emptyMessage}</div>}
         </div>
     );
 }

--- a/src/components/forms/DeviceInfoForm.jsx
+++ b/src/components/forms/DeviceInfoForm.jsx
@@ -17,32 +17,108 @@ export default function DeviceInfoForm({ initial = {}, onSubmit, readOnly = fals
     update("photos", files);
   };
 
+  const infoRow = (label, input) => (
+    <>
+      <div className="asset-info__label">{label}</div>
+      <div>{input}</div>
+    </>
+  );
+
   return (
-    <form id={formId} className="form-grid" onSubmit={handleSubmit}>
-      <label className="form-label" htmlFor="supplier">단말 공급 회사명</label>
-      <input id="supplier" className="form-input" value={form.supplier} onChange={(e) => update("supplier", e.target.value)} placeholder="예: ABC 디바이스" disabled={readOnly} required />
-
-      <label className="form-label" htmlFor="installDate">단말 장착일</label>
-      <input id="installDate" type="date" className="form-input" value={form.installDate} onChange={(e) => update("installDate", e.target.value)} disabled={readOnly} required />
-
-      <label className="form-label" htmlFor="installer">장착자 이름</label>
-      <input id="installer" className="form-input" value={form.installer} onChange={(e) => update("installer", e.target.value)} placeholder="예: 홍길동" disabled={readOnly} required />
-
-      <label className="form-label" htmlFor="serial">단말 일련번호</label>
-      <input id="serial" className="form-input" value={form.serial} onChange={(e) => update("serial", e.target.value)} placeholder="예: DEV-2024-0001" disabled={readOnly} required />
-
-      <label className="form-label" htmlFor="photos">장착 단말 정보 (사진 업로드)</label>
-      <input id="photos" type="file" className="form-input" accept="image/*" capture="environment" multiple onChange={handlePhotos} disabled={readOnly} />
-      {Array.isArray(form.photos) && form.photos.length > 0 && (
-        <div style={{ fontSize: 12, color: "#555" }}>{form.photos.map((f) => f.name).join(", ")}</div>
-      )}
-
-      {!readOnly && showSubmit && (
-        <div className="form-actions">
-          <button type="submit" className="form-button">저장</button>
+    <div className="asset-dialog">
+      <div className="asset-dialog__body">
+        <div className="asset-doc" style={{ marginBottom: 16 }}>
+          <div className="asset-doc__title">단말 장착 사진</div>
+          <div className="asset-doc__box" aria-label="단말 장착 사진 업로드">
+            {readOnly ? (
+              <div className="asset-doc__placeholder">
+                {Array.isArray(form.photos) && form.photos.length > 0
+                  ? `${form.photos.length}개 파일 등록됨`
+                  : "등록된 파일 없음"
+                }
+              </div>
+            ) : (
+              <label style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+                <input
+                  id="photos"
+                  type="file"
+                  accept="image/*"
+                  capture="environment"
+                  multiple
+                  onChange={handlePhotos}
+                  disabled={readOnly}
+                />
+                <div className="asset-doc__placeholder">
+                  {Array.isArray(form.photos) && form.photos.length > 0
+                    ? `${form.photos.length}개 파일 선택됨`
+                    : "파일 선택/촬영"
+                  }
+                </div>
+              </label>
+            )}
+          </div>
         </div>
-      )}
-    </form>
+
+        <form id={formId} onSubmit={handleSubmit}>
+          <div className="asset-info grid-info">
+            {infoRow(
+              "단말 공급사",
+              <input
+                id="supplier"
+                className="form-input"
+                value={form.supplier}
+                onChange={(e) => update("supplier", e.target.value)}
+                placeholder="예: ABC 디바이스"
+                disabled={readOnly}
+                required
+              />
+            )}
+            {infoRow(
+              "단말 장착일",
+              <input
+                id="installDate"
+                type="date"
+                className="form-input"
+                value={form.installDate}
+                onChange={(e) => update("installDate", e.target.value)}
+                disabled={readOnly}
+                required
+              />
+            )}
+            {infoRow(
+              "장착자 이름",
+              <input
+                id="installer"
+                className="form-input"
+                value={form.installer}
+                onChange={(e) => update("installer", e.target.value)}
+                placeholder="예: 홍길동"
+                disabled={readOnly}
+                required
+              />
+            )}
+            {infoRow(
+              "단말 시리얼번호",
+              <input
+                id="serial"
+                className="form-input"
+                value={form.serial}
+                onChange={(e) => update("serial", e.target.value)}
+                placeholder="예: DEV-2024-0001"
+                disabled={readOnly}
+                required
+              />
+            )}
+          </div>
+
+          {!readOnly && showSubmit && (
+            <div className="asset-dialog__footer">
+              <button type="submit" className="form-button">저장</button>
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -1057,12 +1057,23 @@ export default function AssetStatus() {
             <Modal
                 isOpen={showDeviceModal && activeAsset}
                 onClose={() => setShowDeviceModal(false)}
-                title={`단말 정보 등록 - ${activeAsset?.id || ""}`}
-                formId={deviceReadOnly ? undefined : "device-info"}
-                onSubmit={deviceReadOnly ? undefined : handleDeviceInfoSubmit}
+                title={`단말 정보 ${deviceReadOnly ? '보기' : '등록'} - ${activeAsset?.plate || activeAsset?.id || ""}`}
+                showFooter={false}
             >
-                <DeviceInfoForm formId="device-info" initial={deviceInitial} onSubmit={handleDeviceInfoSubmit} readOnly={deviceReadOnly} showSubmit={false} />
+                <DeviceInfoForm
+                    formId="device-info"
+                    initial={deviceInitial}
+                    onSubmit={handleDeviceInfoSubmit}
+                    readOnly={deviceReadOnly}
+                    showSubmit={!deviceReadOnly}
+                />
                 <DeviceEventLog assetId={activeAsset?.id} fallbackInstallDate={deviceInitial?.installDate || "" || activeAsset?.deviceInstallDate || activeAsset?.installDate || ""} />
+
+                {deviceReadOnly && (
+                    <div className="asset-dialog__footer">
+                        <button type="button" className="form-button" onClick={() => setShowDeviceModal(false)}>닫기</button>
+                    </div>
+                )}
             </Modal>
 
             <Table columns={dynamicColumns} data={filtered} selection={selection} emptyMessage="조건에 맞는 차량 자산이 없습니다." stickyHeader />


### PR DESCRIPTION
feat(table): add sortable header toggle and apply to contracts page

## Summary
- Add sortable header toggle to shared `Table` and Rentals page table.
- Single compact toggle per header: first click asc, then asc/desc toggles.
- Type-aware, stable sorting (dates, numbers, strings, empty last).
- Accessibility: `aria-sort`, button labels/titles.
- UI polish: lighter triangles, smaller size, vertical centering.

## Changes
- `src/components/Table.jsx`: Sorting state, toggle UI, stable sort, `initialSort` prop, `sortable`/`sortAccessor`/`sorter` support.
- `src/pages/RentalContracts.jsx`: Per-page sorting wired with sensible accessors for period/amount/status; apply header toggle UI.
- `src/App.css`: Styles for header toggle and vertical centering.

## Screenshots / GIFs
- Before/After headers with sort toggle on Assets and Contracts tables.
- Optional: short capture showing toggle asc?desc.

## Testing Notes
- Build: `npm run build` passes.
- Dev: `npm run dev:full` (or `npm run dev` + backend) and check:
  - /#/assets: click column headers to toggle sort; `select` column not sortable.
  - /#/rentals/table: verify rental_amount numeric sort, rental_period (start date) sort, engine_status/restart_blocked/accident boolean sort.
  - Sticky header layout unaffected; triangles smaller and centered.
  - Sorting is stable (equal values keep original order).
- Optional: pass `initialSort={{ key: "plate", direction: "asc" }}` to `Table` to set default sort.

## Compatibility / Docs
- Backward-compatible. `Table` accepts optional `initialSort` and column-level `sortable`, `sortAccessor`, `sorter`.
- No API/index.html changes; docs unchanged.

## Checklist
- [x] Compiles locally
- [x] Basic manual QA on assets and contracts tables
- [ ] Attach screenshots/GIFs
- [ ] Link related issue(s)

## Links / Issues
- Closes: (add if applicable)