### PR TITLE
fix: restyle popup link buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -907,17 +907,45 @@ body {
 
 /* Utility Classes for Inline Style Replacements */
 .link-button {
-    background: none;
-    border: none;
-    color: #2563eb;
-    text-decoration: underline;
+    --link-accent: #0057e7;
+    --link-accent-dark: #064dc9;
+    --link-accent-light: rgba(0, 87, 231, 0.08);
+    --link-accent-border: rgba(0, 87, 231, 0.16);
+    background: var(--link-accent-light);
+    border: 1px solid var(--link-accent-border);
+    color: var(--link-accent-dark);
+    text-decoration: none;
     cursor: pointer;
-    padding: 0;
+    padding: 0.22rem 0.6rem;
     font: inherit;
+    font-weight: 600;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    line-height: 1.1;
+    white-space: nowrap;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+    transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease,
+        transform 0.18s ease;
 }
 
 .link-button:hover {
-    color: #1d4ed8;
+    background: rgba(0, 87, 231, 0.16);
+    border-color: rgba(0, 87, 231, 0.28);
+    color: var(--link-accent);
+    box-shadow: 0 6px 16px -10px rgba(0, 87, 231, 0.55);
+}
+
+.link-button:focus-visible {
+    outline: 2px solid rgba(0, 87, 231, 0.55);
+    outline-offset: 2px;
+}
+
+.link-button:active {
+    background: rgba(0, 87, 231, 0.22);
+    border-color: rgba(0, 87, 231, 0.35);
+    box-shadow: 0 2px 6px -4px rgba(0, 87, 231, 0.4);
+    transform: translateY(1px);
 }
 
 .file-info {


### PR DESCRIPTION
## Summary
- restyle the popup trigger link buttons with pill-shaped ghost button styling that matches the app palette
- add hover, focus, and active feedback for improved affordance while keeping the look lightweight

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15a0690448332a3c093fd7f684f9a