### PR TITLE
fix: show currency symbol on monthly rental amount

### DIFF
--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -763,7 +763,7 @@ export default function RentalContracts() {
                     <StatusBadge variant={row.isLongTerm ? "badge--contract-term" : "badge--contract-term-short"}>{row.isLongTerm ? "장기" : "단기"}</StatusBadge>
                     <StatusBadge variant="badge--contract-amount">
                         {row.isLongTerm
-                            ? `월${new Intl.NumberFormat("ko-KR").format(
+                            ? `월 ₩${new Intl.NumberFormat("ko-KR").format(
                                   Math.floor(amount / Math.max(1, Math.floor((row.rental_duration_days || 1) / 30)))
                               )}`
                             : `총 ₩${formattedAmount}`}


### PR DESCRIPTION
## Summary
- show the won symbol before monthly rental amounts on the contract list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15a9851108332981ab71f2d751031