### PR TITLE
fix: adjust accident registration column width

### DIFF
--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -32,7 +32,7 @@ const DEFAULT_COLUMN_CONFIG = [
     { key: "contractStatus", label: "계약 상태", visible: true, required: false },
     { key: "engine_status", label: "엔진 상태", visible: true, required: false },
     { key: "restart_blocked", label: "재시동 금지", visible: true, required: false },
-    { key: "accident", label: "사고 등록", visible: true, required: false, width: 160 },
+    { key: "accident", label: "사고 등록", visible: true, required: false, width: 100 },
     { key: "memo", label: "메모", visible: true, required: false },
 ];
 


### PR DESCRIPTION
## Summary
- reduce the default width of the accident registration column in the contracts table so it better matches the button content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15ae3360883329558d0a3677069c9