### PR TITLE
fix: ensure insurance badge button styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -200,13 +200,16 @@
 
 .badge-button {
     border: none;
-    background: transparent;
     cursor: pointer;
     font: inherit;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     padding: 0;
+}
+
+.badge-button:not(.badge) {
+    background: transparent;
 }
 
 .badge-button.badge {


### PR DESCRIPTION
## Summary
- stop overriding badge background styles when buttons also use the badge class
- ensure badge-styled buttons retain the same pill appearance as other badges, fixing the insurance registration control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15b018df08332bf4c3d6e3cf1ef44