### PR TITLE
feat: 회사 필터 해제 기능 추가 (Assets 페이지)

### DIFF
--- a/src/components/filters/ColumnFilterPopover.jsx
+++ b/src/components/filters/ColumnFilterPopover.jsx
@@ -16,6 +16,7 @@ export default function ColumnFilterPopover({
   const isMulti = type === "multi-select";
   const isManagementStageFilter = column?.key === "managementStage";
   const isContractStatusFilter = column?.key === "contractStatus";
+  const isCompanyFilter = column?.key === "company";
   const isVehicleHealthFilter = column?.key === "vehicleHealth";
   const isDeviceStatusFilter = column?.key === "deviceStatus";
   const isVehicleTypeFilter = column?.key === "vehicleType";
@@ -177,7 +178,7 @@ export default function ColumnFilterPopover({
   return (
     <div ref={containerRef} className={popoverClassName} role="dialog" aria-label={`${thStyle} 필터`}>
       <div className="filter-popover__content">
-        {(isManagementStageFilter || isContractStatusFilter) && (type === "select" || type === "multi-select") && (
+        {(isManagementStageFilter || isContractStatusFilter || isCompanyFilter) && (type === "select" || type === "multi-select") && (
           <>
             <button
               type="button"
@@ -186,7 +187,7 @@ export default function ColumnFilterPopover({
                 setSelected([]);
                 onClear && onClear();
               }}
-              aria-label={isManagementStageFilter ? "관리상태 선택 해제" : "계약상태 선택 해제"}
+              aria-label={isManagementStageFilter ? "관리상태 선택 해제" : isContractStatusFilter ? "계약상태 선택 해제" : "회사 선택 해제"}
             >
               <span aria-hidden="true" className="filter-management-clear__checkbox" />
               <span className="filter-management-clear__label">선택해제</span>


### PR DESCRIPTION
## 변경 내용
- Assets 페이지 회사 필터(Company Filter)에 '선택 해제' 버튼 추가
- 기존 관리상태/계약상태 필터와 동일한 UI/UX 적용

## 배경
- 회사 필터 선택 후 해제 기능 부재로 인해 전체 목록을 보려면 새로고침이 강제됨.
- Super-admin 및 다수 업체를 관리하는 사용자의 편의성 증대.

## 테스트
- 회사 필터 선택 후 팝업 내 '선택해제' 버튼 노출 확인
- 버튼 클릭 시 필터 초기화 및 전체 목록 조회 확인

## 이슈
https://github.com/ProjectPrometheusFindrive/Project_Prometheus_BE/issues/15
https://github.com/ProjectPrometheusFindrive/Project_Prometheus_BE/issues/16

<img width="583" height="409" alt="image" src="https://github.com/user-attachments/assets/ce6bcc74-96e1-4c77-9159-4bcb2d926d92" />
<img width="536" height="391" alt="image" src="https://github.com/user-attachments/assets/d723712a-611d-42d4-9f58-fba14adbc0ba" />
