### PR TITLE
fix(terms): 약관 페이지 스크롤 및 동의 버튼 분리

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4345,8 +4345,9 @@ body {
 
 .terms-page {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  overflow: hidden;
 }
 
 .terms-page__sidebar {
@@ -4429,7 +4430,7 @@ body {
   padding: 2rem;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .terms-card {
@@ -4440,7 +4441,6 @@ body {
   padding: 2rem;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   animation: slideUp 0.5s ease-out;
 }
 
@@ -4461,31 +4461,61 @@ body {
   margin: 0;
 }
 
+.terms-card__select-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
 .terms-card__select-all {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1.25rem;
-  background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #86efac;
-  border-radius: 12px;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
   cursor: pointer;
   transition: all 0.2s ease;
+  font-size: 0.875rem;
 }
 
-.terms-card__select-all:hover {
-  background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 100%);
+.terms-card__select-all--required {
+  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+  border: 2px solid #fca5a5;
+}
+
+.terms-card__select-all--required:hover {
+  background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+}
+
+.terms-card__select-all--required input {
+  accent-color: #dc2626;
+}
+
+.terms-card__select-all--required span {
+  font-weight: 600;
+  color: #dc2626;
+}
+
+.terms-card__select-all--optional {
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+  border: 2px solid #cbd5e1;
+}
+
+.terms-card__select-all--optional:hover {
+  background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
+}
+
+.terms-card__select-all--optional input {
+  accent-color: #64748b;
+}
+
+.terms-card__select-all--optional span {
+  font-weight: 600;
+  color: #64748b;
 }
 
 .terms-card__select-all input {
-  width: 20px;
-  height: 20px;
-  accent-color: #22c55e;
-}
-
-.terms-card__select-all span {
-  font-weight: 600;
-  color: #166534;
+  width: 18px;
+  height: 18px;
 }
 
 .terms-card__list {
@@ -4493,9 +4523,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow-y: auto;
-  padding-right: 0.5rem;
-  min-height: 0;
 }
 
 .terms-item {

--- a/src/pages/TermsAgreement.jsx
+++ b/src/pages/TermsAgreement.jsx
@@ -21,13 +21,20 @@ export default function TermsAgreement() {
     }));
   };
 
-  const handleSelectAll = () => {
-    const allChecked = agreements.privacy && agreements.location && agreements.marketing;
-    setAgreements({
-      privacy: !allChecked,
-      location: !allChecked,
-      marketing: !allChecked
-    });
+  const handleSelectAllRequired = () => {
+    const allRequiredChecked = agreements.privacy && agreements.location;
+    setAgreements(prev => ({
+      ...prev,
+      privacy: !allRequiredChecked,
+      location: !allRequiredChecked
+    }));
+  };
+
+  const handleSelectOptional = () => {
+    setAgreements(prev => ({
+      ...prev,
+      marketing: !prev.marketing
+    }));
   };
 
   const handleNext = () => {
@@ -39,7 +46,7 @@ export default function TermsAgreement() {
   };
 
   const canProceed = agreements.privacy && agreements.location;
-  const allChecked = agreements.privacy && agreements.location && agreements.marketing;
+  const allRequiredChecked = agreements.privacy && agreements.location;
 
   return (
     <div className="terms-page">
@@ -71,14 +78,24 @@ export default function TermsAgreement() {
         <div className="terms-card">
           <div className="terms-card__header">
             <h2 className="terms-card__title">약관 동의</h2>
-            <label className="terms-card__select-all">
-              <input
-                type="checkbox"
-                checked={allChecked}
-                onChange={handleSelectAll}
-              />
-              <span>전체 동의</span>
-            </label>
+            <div className="terms-card__select-buttons">
+              <label className="terms-card__select-all terms-card__select-all--required">
+                <input
+                  type="checkbox"
+                  checked={allRequiredChecked}
+                  onChange={handleSelectAllRequired}
+                />
+                <span>필수 전체 동의</span>
+              </label>
+              <label className="terms-card__select-all terms-card__select-all--optional">
+                <input
+                  type="checkbox"
+                  checked={agreements.marketing}
+                  onChange={handleSelectOptional}
+                />
+                <span>선택 동의</span>
+              </label>
+            </div>
           </div>
 
           <div className="terms-card__list">


### PR DESCRIPTION
## Summary
- 약관 페이지 전체 스크롤 추가
- "전체 동의" 버튼을 "필수 전체 동의"와 "선택 동의" 버튼으로 분리
- 필수 동의 미체크 시 다음 단계 버튼 비활성화 유지

Closes #41