### PR TITLE
fix(signup): 아이디 입력 안내문구를 업무용 이메일로 수정

### DIFF
--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -164,7 +164,7 @@ export default function SignUp() {
 
     switch (fieldName) {
       case 'userId':
-        if (!value) return { status: 'default', text: '이메일 형식으로 입력해주세요' };
+        if (!value) return { status: 'default', text: '업무용 이메일을 입력해주세요' };
         if (validateEmail(value)) return { status: 'success', text: '올바른 형식입니다' };
         return { status: 'error', text: '올바른 이메일 형식을 입력해주세요' };
 


### PR DESCRIPTION
## Summary
- 회원가입 2단계의 아이디 입력 필드 안내문구를 "업무용 이메일을 입력해주세요"로 수정

## Changes
- `src/pages/SignUp.jsx`: 아이디 필드의 기본 힌트 텍스트 변경
  - 변경 전: "이메일 형식으로 입력해주세요"
  - 변경 후: "업무용 이메일을 입력해주세요"

Closes #42