### PR TITLE
fix(auth): keep terms footer visible

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4345,8 +4345,9 @@ body {
 
 .terms-page {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  overflow: hidden;
 }
 
 .terms-page__sidebar {
@@ -4429,7 +4430,8 @@ body {
   padding: 2rem;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .terms-card {
@@ -4440,7 +4442,6 @@ body {
   padding: 2rem;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   animation: slideUp 0.5s ease-out;
 }
 


### PR DESCRIPTION
﻿# 변경 내용
- 약관 동의 화면에서 내용 영역에 세로 스크롤을 부여하고, 페이지 높이를 고정해 하단 버튼이 항상 보이도록 수정했습니다.

# 테스트
- chrome-devtools MCP로 약관 동의 화면 진입 후 하단 "다음 단계" 버튼이 화면에 노출되는지 확인
