### PR TITLE
fix(asset): enable manual terminal count input

### DIFF
--- a/src/components/modals/TerminalRequestModal.jsx
+++ b/src/components/modals/TerminalRequestModal.jsx
@@ -293,7 +293,8 @@ export default function TerminalRequestModal({ isOpen, onClose, defaults }) {
                                     className={`terminal-request-input terminal-request-input--stepper ${fieldErrors.expectedVehicleCount ? "is-invalid" : ""}`}
                                     value={form.expectedVehicleCount}
                                     onChange={(e) => updateField("expectedVehicleCount", e.target.value.replace(/\D/g, ""))}
-                                    readOnly
+                                    inputMode="numeric"
+                                    pattern="[0-9]*"
                                 />
                                 <div className="terminal-request-stepper-buttons">
                                     <button type="button" className="terminal-request-stepper-btn terminal-request-stepper-btn--minus" onClick={decrementCount}>


### PR DESCRIPTION
﻿# 변경 내용
- 단말장착신청 모달의 신청 장착 대수를 직접 입력할 수 있도록 숫자 입력 모드를 추가했습니다.

# 테스트
- chrome-devtools MCP에서 단말장착신청 모달 열기
- "신청 장착 대수" 입력란에 숫자 직접 입력되는지 확인
