### PR TITLE
fix(asset): 보험 만료 경고 표시

### DIFF
--- a/src/components/cells/InsuranceCell.jsx
+++ b/src/components/cells/InsuranceCell.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateShort } from '../../utils/date';
+import { formatDateShort, getInsuranceExpiryStatus } from '../../utils/date';
 
 /**
  * 보험 만료일 셀 컴포넌트
@@ -7,15 +7,33 @@ import { formatDateShort } from '../../utils/date';
  */
 const InsuranceCell = React.memo(({ insuranceExpiryDate, onViewInsurance, onRegisterInsurance }) => {
   if (insuranceExpiryDate) {
+    const status = getInsuranceExpiryStatus(insuranceExpiryDate);
+    const colorByStatus = {
+      expired: "#d32f2f",
+      warning: "#f9a825",
+      caution: "#fbc02d",
+      valid: "#006CEC",
+      none: "#006CEC",
+    };
+    const labelByStatus = {
+      expired: "만료",
+      warning: "만료 임박",
+      caution: "만료 예정",
+    };
+    const statusLabel = labelByStatus[status];
+    const displayDate = formatDateShort(insuranceExpiryDate);
+    const displayText = status === "expired" ? `${statusLabel} ${displayDate}` : displayDate;
+    const ariaStatus = statusLabel ? `(${statusLabel}) ` : "";
     return (
       <button
         type="button"
         className="simple-button"
         onClick={onViewInsurance}
         title="보험 정보 보기"
-        aria-label={`보험 만료일 ${formatDateShort(insuranceExpiryDate)} 상세보기`}
+        aria-label={`보험 만료일 ${ariaStatus}${displayDate} 상세보기`}
+        style={{ color: colorByStatus[status] || "#006CEC" }}
       >
-        {formatDateShort(insuranceExpiryDate)}
+        {displayText}
       </button>
     );
   }

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -37,7 +37,7 @@ import useTableSelection from '../hooks/useTableSelection';
 // Local storage fallbacks removed; use API persistence instead
 import { ASSET } from '../constants';
 import { MANAGEMENT_STAGE_OPTIONS } from '../constants/forms';
-import { formatDateShort } from '../utils/date';
+import { formatDateShort, getInsuranceExpiryStatus } from '../utils/date';
 import {
   getManagementStage,
   withManagementStage,
@@ -891,6 +891,22 @@ export default function AssetStatus() {
         return formatDateShort(row.registrationDate);
       case 'insuranceExpiryDate':
         if (row.insuranceExpiryDate) {
+          const status = getInsuranceExpiryStatus(row.insuranceExpiryDate);
+          const colorByStatus = {
+            expired: '#d32f2f',
+            warning: '#f9a825',
+            caution: '#fbc02d',
+            valid: '#006CEC',
+            none: '#006CEC',
+          };
+          const labelByStatus = {
+            expired: '만료',
+            warning: '만료 임박',
+            caution: '만료 예정',
+          };
+          const displayDate = formatDateShort(row.insuranceExpiryDate);
+          const statusLabel = labelByStatus[status];
+          const displayText = status === 'expired' ? `${statusLabel} ${displayDate}` : displayDate;
           return (
             <div
               style={{
@@ -906,7 +922,7 @@ export default function AssetStatus() {
                 title="보험 정보 보기"
                 style={{
                   textAlign: 'center',
-                  color: '#006CEC',
+                  color: colorByStatus[status] || '#006CEC',
                   fontSize: '14px',
                   fontFamily: 'Pretendard',
                   fontWeight: 500,
@@ -918,7 +934,7 @@ export default function AssetStatus() {
                   padding: 0,
                 }}
               >
-                {formatDateShort(row.insuranceExpiryDate)}
+                {displayText}
               </button>
             </div>
           );

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -27,9 +27,23 @@ export function formatDisplayDate(value, locale) {
   return d ? d.toLocaleDateString(locale) : "-";
 }
 
+// Returns insurance expiry status based on today
+export function getInsuranceExpiryStatus(expiryDate) {
+  const expiry = safeDate(expiryDate);
+  if (!expiry) return "none";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  expiry.setHours(0, 0, 0, 0);
+  const diffDays = Math.ceil((expiry - today) / (1000 * 60 * 60 * 24));
+  if (diffDays < 0) return "expired";
+  if (diffDays <= 30) return "warning";
+  if (diffDays <= 60) return "caution";
+  return "valid";
+}
+
 export default {
   safeDate,
   formatDateShort,
   formatDisplayDate,
+  getInsuranceExpiryStatus,
 };
-


### PR DESCRIPTION
# 변경 내용
- 보험 만료일 기준으로 만료/임박/예정 상태 색상을 반영했습니다.
- 만료된 보험은 "만료" 텍스트를 함께 표시합니다.

# 테스트
- MCP 자산등록관리에서 보험 만료일 '25.01.01 항목이 빨간색과 "만료" 텍스트로 표시되는지 확인