### PR TITLE
fix(asset): 진단코드 발생일 기준 정렬

### DIFF
--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -98,6 +98,15 @@ const normalizeDiagnosticList = (asset) => {
   return [];
 };
 
+const sortDiagnosticsByDateDesc = (issues) => {
+  if (!Array.isArray(issues)) return [];
+  return [...issues].sort((a, b) => {
+    const aTime = a?.detectedDate ? new Date(a.detectedDate).getTime() : 0;
+    const bTime = b?.detectedDate ? new Date(b.detectedDate).getTime() : 0;
+    return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
+  });
+};
+
 const severityNumber = (s) => {
   if (typeof s === 'number') return Math.max(0, Math.min(10, s));
   if (typeof s === 'string') {
@@ -578,12 +587,13 @@ export default function AssetStatus() {
       const issues = Array.isArray(diag?.diagnosticCodes)
         ? diag.diagnosticCodes
         : normalizeDiagnosticList(v);
+      const sortedIssues = sortDiagnosticsByDateDesc(issues);
       const detail = {
         category: 'ALL',
         categoryName: '전체 진단',
-        count: issues.length,
+        count: sortedIssues.length,
         vehicleInfo: { plate: v.plate, vehicleType: v.vehicleType, id: v.id },
-        issues,
+        issues: sortedIssues,
       };
       setDiagnosticDetail(detail);
       setShowDiagnosticModal(true);


### PR DESCRIPTION
# 변경 내용
- 진단 코드 상세 팝업에서 발생일 기준(최근 먼저)으로 정렬했습니다.

# 테스트
- MCP 자산등록관리에서 11가1003 진단코드 상세 팝업을 열어 2025-09-26이 첫 번째로 표시되는지 확인