### PR TITLE
fix(asset): 단말/차량상태/심각도 정렬

### DIFF
--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -1294,6 +1294,8 @@ export default function AssetStatus() {
             ? {
                 key: column.key,
                 label: column.label,
+                sortable: true,
+                sortAccessor: (row) => (row.deviceSerial ? 1 : 0),
                 style: {
                   textAlign: 'center',
                   ...(column.width
@@ -1443,6 +1445,22 @@ export default function AssetStatus() {
                   ...(column.key === 'insuranceExpiryDate' ? { filterType: 'date-range' } : null),
                   ...(column.key === 'vehicleHealth'
                     ? {
+                        sortAccessor: (row) => {
+                          const hasDevice = !!row?.deviceSerial;
+                          if (!hasDevice) return '단말필요';
+                          const dcount = getDiagnosticCount(row);
+                          if (dcount === 0) return '정상';
+                          const provided = row.diagnosticStatus;
+                          if (provided) return provided;
+                          const arr = Array.isArray(row?.diagnosticCodes)
+                            ? row.diagnosticCodes
+                            : [];
+                          const max = arr.reduce(
+                            (acc, it) => Math.max(acc, severityNumber(it?.severity)),
+                            0
+                          );
+                          return max > 7 ? '심각' : '관심필요';
+                        },
                         filterType: 'select',
                         filterAccessor: (row) => {
                           const hasDevice = !!row?.deviceSerial;
@@ -1473,6 +1491,24 @@ export default function AssetStatus() {
                     : null),
                   ...(column.key === 'severity'
                     ? {
+                        sortAccessor: (row) => {
+                          const fromField =
+                            typeof row?.diagnosticMaxSeverity === 'number'
+                              ? row.diagnosticMaxSeverity
+                              : null;
+                          let max = fromField;
+                          if (max == null) {
+                            const arr = Array.isArray(row?.diagnosticCodes)
+                              ? row.diagnosticCodes
+                              : [];
+                            if (arr.length === 0) return 0;
+                            max = arr.reduce(
+                              (acc, it) => Math.max(acc, severityNumber(it?.severity)),
+                              0
+                            );
+                          }
+                          return Number(max) || 0;
+                        },
                         filterType: 'number-range',
                         filterAccessor: (row) => {
                           const fromField =


### PR DESCRIPTION
# 변경 내용
- 단말상태/차량상태/심각도 컬럼에 정렬 기준값을 추가했습니다.

# 테스트
- MCP 자산등록관리에서 단말상태 정렬 클릭 시 단말등록 항목이 상단으로 이동하는지 확인
- MCP 자산등록관리에서 심각도 정렬 클릭 시 8.0 → 5.0 → 2.0 순으로 정렬되는지 확인