### PR TITLE
fix(asset): persist management stage updates

### DIFF
--- a/src/hooks/useManagementStage.js
+++ b/src/hooks/useManagementStage.js
@@ -24,7 +24,8 @@ export default function useManagementStage(options) {
     if (!asset?.id || !nextStage) return;
     const assetId = asset.id;
     const previousStage = getManagementStage ? getManagementStage(asset) : asset?.managementStage;
-    if (previousStage === nextStage) return;
+    const hasExplicitStage = asset?.__hasManagementStage ?? Boolean(asset?.managementStage && String(asset.managementStage).trim());
+    if (previousStage === nextStage && hasExplicitStage) return;
 
     // Guardrails based on rentals consistency
     try {

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -448,10 +448,11 @@ export default function AssetStatus() {
         setStageDropdownUp(false);
         return;
       }
-      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
       const rect = trigger.getBoundingClientRect();
-      const spaceBelow = viewportHeight - rect.bottom;
-      const spaceAbove = rect.top;
+      const wrapRect = tableWrapRef.current?.getBoundingClientRect();
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+      const spaceBelow = wrapRect ? wrapRect.bottom - rect.bottom : viewportHeight - rect.bottom;
+      const spaceAbove = wrapRect ? rect.top - wrapRect.top : rect.top;
       const dropdownHeight = listEl.offsetHeight || listEl.scrollHeight || 0;
       const gap = 8; // matches CSS spacing
       const shouldFlipUp = spaceBelow < dropdownHeight + gap && spaceAbove > spaceBelow;


### PR DESCRIPTION
﻿## 변경 내용
- 관리상태가 계산값과 동일해도 명시값이 없는 경우 저장하도록 처리
- 테이블 내부 스크롤 기준으로 관리상태 드롭다운 위치 재계산

## 테스트
- 자산등록관리에서 관리상태가 "-"로 보이는 행 선택 후 "입고대상" 변경 → 상태 표시 갱신 확인
- 목록 마지막 행에서 관리상태 드롭다운 열림 확인

## 이슈
- #57
