### PR TITLE
fix(table): keep filter popovers visible

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -284,6 +284,14 @@ body {
   overflow: hidden; /* Ensure rounded corners are visible */
 }
 
+.table-wrap--filter-open {
+  overflow-y: visible;
+}
+
+.table-wrap--filter-open.table-wrap--scroll-x {
+  overflow-y: visible;
+}
+
 .table-wrap--scroll-x {
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -370,7 +370,7 @@ export default function Table({
     if (stickyHeader) {
         return (
             <div ref={wrapRef} className="table-wrap--sticky" style={stickyStyle}>
-                <div className="table-wrap">
+                <div className={["table-wrap", openFilterKey ? "table-wrap--filter-open" : null].filter(Boolean).join(" ")}>
                     {tableContent}
                 </div>
             </div>
@@ -378,7 +378,7 @@ export default function Table({
     }
 
     return (
-        <div ref={wrapRef} className="table-wrap table-wrap--scroll-x">
+        <div ref={wrapRef} className={["table-wrap", "table-wrap--scroll-x", openFilterKey ? "table-wrap--filter-open" : null].filter(Boolean).join(" ")}>
             {tableContent}
         </div>
     );


### PR DESCRIPTION
﻿## 변경 내용
- 컬럼 필터 팝오버가 열릴 때 테이블 래퍼의 세로 overflow를 열어 짧은 결과/빈 결과에서도 팝오버가 보이도록 처리

## 테스트
- 차종을 소수 결과로 필터링한 뒤 차종 필터 팝오버가 정상 표시됨 확인
- 결과가 0건일 때도 필터 팝오버가 열리는 것 확인

## 이슈
- #54
- #55
