### PR TITLE
fix: OCR 자동채움 신뢰도 기준 적용

### DIFF
--- a/src/components/OcrSuggestionPicker.jsx
+++ b/src/components/OcrSuggestionPicker.jsx
@@ -20,7 +20,9 @@ function confidenceColor(confidence) {
 }
 
 export default function OcrSuggestionPicker({ items = [], onApply, style = {}, showLabel = true, maxWidth = 220 }) {
-  const list = Array.isArray(items) ? items.filter((it) => it && typeof it.value !== "undefined") : [];
+  const list = Array.isArray(items)
+    ? items.filter((it) => it && typeof it.value !== "undefined" && normalizeConfidence(it.confidence) >= 0.4)
+    : [];
   const initialIndex = useMemo(() => {
     if (list.length === 0) return 0;
     let best = 0;
@@ -38,7 +40,7 @@ export default function OcrSuggestionPicker({ items = [], onApply, style = {}, s
   React.useEffect(() => {
     if (appliedRef.current) return;
     const best = list[initialIndex];
-    if (best && typeof onApply === "function") {
+    if (best && normalizeConfidence(best.confidence) >= 0.7 && typeof onApply === "function") {
       onApply(best.value);
       appliedRef.current = true;
     }


### PR DESCRIPTION
﻿## 변경 내용
- OCR 제안 표시/자동채움에 신뢰도 기준(40% 표시, 70% 자동)을 적용
- 연료 타입/등록증 주요 필드 자동 입력을 70% 이상으로 제한

## 테스트
- 자산등록 > OCR 제안 데이터 수신 시 70% 미만 자동 채움 미동작 확인 (OCR 데이터가 없어 수동 검증은 어려움)

## 이슈
- closes #43
