### PR TITLE
fix: 사고정보 모달 레이어 및 영상 업로드 제한

### DIFF
--- a/src/components/modals/AccidentInfoModal.css
+++ b/src/components/modals/AccidentInfoModal.css
@@ -10,7 +10,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 1300;
 }
 
 .accident-modal {

--- a/src/hooks/useAccidentReport.js
+++ b/src/hooks/useAccidentReport.js
@@ -15,6 +15,18 @@ const DEFAULT_FORM = {
   blackboxFileName: "",
 };
 
+const VIDEO_EXTENSIONS = new Set(["mp4", "avi", "mov", "mpeg", "mpg"]);
+
+const isVideoFile = (file) => {
+  if (!file) return false;
+  const type = String(file.type || "").toLowerCase();
+  if (type.startsWith("video/")) return true;
+  const name = String(file.name || "");
+  const idx = name.lastIndexOf(".");
+  const ext = idx >= 0 ? name.slice(idx + 1).toLowerCase() : "";
+  return ext ? VIDEO_EXTENSIONS.has(ext) : false;
+};
+
 export default function useAccidentReport({ setItems, setSelectedContract }) {
   const [showAccidentModal, setShowAccidentModal] = useState(false);
   const [showAccidentInfoModal, setShowAccidentInfoModal] = useState(false);
@@ -29,6 +41,15 @@ export default function useAccidentReport({ setItems, setSelectedContract }) {
 
   const handleAccidentFileChange = (event) => {
     const file = event.target?.files && event.target.files[0] ? event.target.files[0] : null;
+    if (file && !isVideoFile(file)) {
+      emitToast("동영상 파일만 업로드할 수 있습니다.", "warning");
+      setAccidentForm((prev) => ({
+        ...prev,
+        blackboxFile: null,
+        blackboxFileName: "",
+      }));
+      return;
+    }
     setAccidentForm((prev) => ({
       ...prev,
       blackboxFile: file,
@@ -139,6 +160,10 @@ export default function useAccidentReport({ setItems, setSelectedContract }) {
 
     try {
       if (blackboxFile) {
+        if (!isVideoFile(blackboxFile)) {
+          emitToast("동영상 파일만 업로드할 수 있습니다.", "warning");
+          return;
+        }
         const typeOk = isFileTypeAllowed(blackboxFile);
         if (!typeOk) {
           emitToast("허용되지 않는 파일 형식입니다.", "warning");

--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -2164,7 +2164,7 @@ export default function RentalContracts() {
                     <input
                       key={fileInputKey}
                       type="file"
-                      accept="video/*,image/*"
+                        accept="video/*"
                       onChange={handleAccidentFileChange}
                       style={{ display: 'none' }}
                     />


### PR DESCRIPTION
﻿## 변경 내용
- 사고정보 조회 모달을 계약 상세 모달 위로 노출되도록 z-index를 상향
- 사고 영상 업로드 입력을 video/*로 제한하고, 비디오 파일만 허용하도록 검증 추가

## 테스트
- 계약 상세 모달에서 사고정보수정 클릭 시 사고 정보 조회 모달이 상단에 노출됨
- 사고등록 모달의 파일 입력 accept가 video/*로 설정됨 (영상 파일만 허용)

## 이슈
- closes #62
