### PR TITLE
(TC-ASSET-032) 컬럼 전체 선택 해제 기능 추가

### DIFF
--- a/src/components/ColumnSettingsMenu.jsx
+++ b/src/components/ColumnSettingsMenu.jsx
@@ -11,6 +11,7 @@ export default function ColumnSettingsMenu({
   onDragEnd,
   onToggleVisibility,
   onReset,
+  onDeselectAll,
 }) {
   const handleItemKey = (e) => {
     const current = e.currentTarget;
@@ -35,6 +36,12 @@ export default function ColumnSettingsMenu({
     }
   };
 
+  const handleDeselectAll = () => {
+    if (onDeselectAll) {
+      onDeselectAll();
+    }
+  };
+
   return (
     <div
       data-column-dropdown
@@ -54,7 +61,7 @@ export default function ColumnSettingsMenu({
       }}
     >
       {/* 초기화 버튼 */}
-      <div style={{ padding: '20px 20px 10px 20px' }}>
+      <div style={{ padding: '20px 20px 10px 20px', display: 'flex', flexDirection: 'column', gap: 10 }}>
         <button
           type="button"
           onClick={handleReset}
@@ -88,6 +95,41 @@ export default function ColumnSettingsMenu({
             초기화
           </div>
         </button>
+        {onDeselectAll && (
+          <button
+            type="button"
+            onClick={handleDeselectAll}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+              width: '100%'
+            }}
+          >
+            <div style={{ width: 16, height: 16, position: 'relative' }}>
+              <div style={{
+                width: 16,
+                height: 16,
+                background: 'white',
+                borderRadius: 3,
+                border: '1px rgba(0, 0, 0, 0.15) solid'
+              }} />
+            </div>
+            <div style={{
+              color: '#888888',
+              fontSize: 14,
+              fontFamily: 'Pretendard',
+              fontWeight: 500,
+              lineHeight: '20px'
+            }}>
+              전체 선택 해제
+            </div>
+          </button>
+        )}
       </div>
 
       {/* 구분선 */}

--- a/src/hooks/useColumnSettings.js
+++ b/src/hooks/useColumnSettings.js
@@ -60,6 +60,13 @@ export default function useColumnSettings({ storageKey, defaultColumns }) {
     persist(resetColumns);
   };
 
+  const deselectAllOptionalColumns = () => {
+    const next = columns.map((col) =>
+      col.required ? col : { ...col, visible: false }
+    );
+    persist(next);
+  };
+
   const visibleColumns = useMemo(() => columns.filter((c) => c.visible), [columns]);
 
   return {
@@ -69,6 +76,7 @@ export default function useColumnSettings({ storageKey, defaultColumns }) {
     toggleColumnVisibility,
     moveColumn,
     resetColumns,
+    deselectAllOptionalColumns,
   };
 }
 

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -229,7 +229,7 @@ export default function AssetStatus() {
     toggleInconsistency,
     closeStage: closeStageDropdown,
   } = useDropdownState();
-  const { columns, visibleColumns, toggleColumnVisibility, moveColumn, resetColumns } =
+  const { columns, visibleColumns, toggleColumnVisibility, moveColumn, resetColumns, deselectAllOptionalColumns } =
     useColumnSettings({
       storageKey: 'asset-columns-settings',
       defaultColumns: DEFAULT_ASSET_COLUMNS,
@@ -1694,6 +1694,7 @@ export default function AssetStatus() {
                   onDragEnd={handleDragEnd}
                   onToggleVisibility={toggleColumnVisibility}
                   onReset={resetColumns}
+                  onDeselectAll={deselectAllOptionalColumns}
                 />
               )}
             </div>

--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -197,7 +197,7 @@ export default function RentalContracts() {
   const [showColumnDropdown, setShowColumnDropdown] = useState(false);
   const [draggedColumnIndex, setDraggedColumnIndex] = useState(null);
   const [dragOverColumnIndex, setDragOverColumnIndex] = useState(null);
-  const { columns, visibleColumns, toggleColumnVisibility, moveColumn, resetColumns } =
+  const { columns, visibleColumns, toggleColumnVisibility, moveColumn, resetColumns, deselectAllOptionalColumns } =
     useColumnSettings({
       storageKey: 'rental-columns-settings',
       defaultColumns: DEFAULT_COLUMN_CONFIG,
@@ -1407,6 +1407,7 @@ export default function RentalContracts() {
                   onDragEnd={handleDragEnd}
                   onToggleVisibility={toggleColumnVisibility}
                   onReset={resetColumns}
+                  onDeselectAll={deselectAllOptionalColumns}
                 />
               )}
             </div>


### PR DESCRIPTION
## 변경 내용
- useColumnSettings에 deselectAllOptionalColumns 함수 추가
- ColumnSettingsMenu에 '전체 선택 해제' 버튼 추가
- RentalContracts와 AssetStatus에 기능 연결

## 관련 이슈
Closes #56

## 테스트
- [x] 컬럼 설정 메뉴에서 '전체 선택 해제' 버튼이 표시되는지 확인
- [x] 버튼 클릭 시 선택 가능한 모든 컬럼이 한 번에 해제되는지 확인