### PR TITLE
(TC-ASSET-040) VIN 중복 등록 차단 기능 추가

### DIFF
--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -848,9 +848,18 @@ export default function AssetStatus() {
         console.debug('[upload-ui] createAsset result:', created);
         const normalized = withManagementStage(created || payload);
         setRows((prev) => [normalized, ...prev]);
+        emitToast('자산이 등록되었습니다.', 'success');
       } catch (e) {
         console.error('Failed to create asset via API', e);
-        emitToast('자산 생성에 실패했습니다.', 'error');
+        // Handle VIN duplicate error (409 Conflict)
+        if (e?.status === 409 || e?.errorType === 'CONFLICT' || e?.data?.error?.type === 'CONFLICT') {
+          const message = e?.data?.error?.message || e?.message || '이미 등록된 VIN입니다.';
+          emitToast(message, 'error');
+        } else {
+          emitToast('자산 생성에 실패했습니다.', 'error');
+        }
+        // Don't close modal on error so user can fix and retry
+        return;
       }
     }
 


### PR DESCRIPTION
## 변경 내용

VIN 중복 등록을 차단하는 기능을 추가했습니다.

### 주요 변경사항

1. **실시간 VIN 중복 체크**
   - `AssetDialog`에서 VIN 입력 시 500ms debounce를 적용하여 실시간 중복 체크
   - 자산 목록(`fetchAssetsSummary`)에서 동일 VIN 검색
   - 중복 발견 시 에러 메시지 표시 및 저장 버튼 비활성화

2. **에러 처리 개선**
   - 자산 생성 시 BE에서 반환하는 409 Conflict 에러 처리
   - 사용자 친화적인 에러 메시지 표시
   - 자산 생성 실패 시 모달을 닫지 않아 재시도 가능

3. **UI/UX 개선**
   - VIN 입력 필드에 중복 확인 상태 표시 ("중복 확인 중...")
   - 중복 VIN 입력 시 빨간색 에러 메시지 표시
   - 중복 체크 중이거나 중복 에러가 있을 때 저장 버튼 비활성화

## 테스트

### 테스트 시나리오

1. **VIN 중복 체크**
   - 자산 등록 팝업에서 기존에 등록된 VIN 입력
   - 500ms 후 "이미 등록된 VIN입니다." 에러 메시지 확인
   - 저장 버튼이 비활성화되는지 확인

2. **자산 생성 시 중복 에러 처리**
   - 중복 VIN으로 자산 생성 시도
   - BE에서 409 Conflict 에러 반환 시 적절한 에러 메시지 표시
   - 모달이 닫히지 않아 재시도 가능한지 확인

3. **정상 등록**
   - 새로운 VIN으로 자산 등록
   - 정상적으로 등록되는지 확인

### 테스트 명령어

```bash
npm run dev
```

1. 로그인: `ppfd@ppfd.com` / `vmfhapxpdntm`
2. 자산 관리 페이지로 이동
3. 자산 등록 버튼 클릭
4. 기존 VIN 입력하여 중복 체크 확인

## 관련 이슈

Closes #44
