### PR TITLE
(TC-MEM-093) Member↔Admin 권한 변경 및 회원 복원 API 연동

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -543,13 +543,13 @@ export async function withdrawMember(userId) {
 }
 
 /**
- * Restore a withdrawn member by approving them again
+ * Restore a withdrawn member
  * @param {string} userId - User ID (email) to restore
  * @returns {Promise<boolean>} True if successful
  */
 export async function restoreMember(userId) {
-    // Backend uses the same approve endpoint for reactivation
-    return await approveMember(userId);
+    const response = await membersApi.restore(userId);
+    return response.status === API_STATUS.SUCCESS;
 }
 
 // Revenue

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -865,6 +865,24 @@ export const membersApi = {
             method: 'POST',
             body: JSON.stringify({ userId })
         });
+    },
+
+    /**
+     * Restore a withdrawn member
+     * @param {string} userId - User ID (email) to restore
+     * @returns {Promise<Object>} Response with success status
+     */
+    async restore(userId) {
+        if (!userId || typeof userId !== 'string') {
+            return createApiResponse(null, API_STATUS.ERROR, {
+                type: API_ERRORS.VALIDATION_ERROR,
+                message: 'userId is required'
+            });
+        }
+        return await apiRequest(API_ENDPOINTS.MEMBERS_RESTORE, {
+            method: 'POST',
+            body: JSON.stringify({ userId })
+        });
     }
 };
 

--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -61,6 +61,7 @@ export const API_ENDPOINTS = {
     MEMBERS_APPROVE: '/members/approve',
     MEMBERS_REJECT: '/members/reject',
     MEMBERS_WITHDRAW: '/members/withdraw',
+    MEMBERS_RESTORE: '/members/restore',
     MEMBER_ROLE: (userId) => `/members/${encodeURIComponent(userId)}/role`,
 
     // Uploads (GCS direct upload helpers)


### PR DESCRIPTION
## Summary
- BE 이슈 #22에서 추가된 회원 복원 API (/members/restore) 연동
- 기존 approve API 재사용에서 전용 restore API 사용으로 변경

## 관련 이슈
- Closes #51

## 변경 사항
- `apiTypes.js`: `MEMBERS_RESTORE` 엔드포인트 추가
- `apiClient.js`: `membersApi.restore()` 메서드 추가
- `api.js`: `restoreMember()` 함수 수정

## Test plan
- [x] 회원관리 페이지에서 탈퇴된 회원 목록 확인
- [x] 복원 버튼 표시 확인
- [ ] 복원 버튼 클릭 시 API 호출 및 상태 변경 확인 (QA)