### PR TITLE
(TC-ASSET-055) BE 자산 상태 자동 업데이트 연동

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -221,7 +221,10 @@ export function transformAsset(asset) {
         ...asset,
         registrationDate: asset.registrationDate ? new Date(asset.registrationDate) : null,
         createdAt: asset.createdAt ? new Date(asset.createdAt) : null,
-        updatedAt: asset.updatedAt ? new Date(asset.updatedAt) : null
+        updatedAt: asset.updatedAt ? new Date(asset.updatedAt) : null,
+        // BE에서 자산 상태 자동 업데이트 필드 유지
+        status: asset.status || null,
+        statusUpdatedAt: asset.statusUpdatedAt ? new Date(asset.statusUpdatedAt) : null
     };
 }
 

--- a/src/pages/AssetStatus.jsx
+++ b/src/pages/AssetStatus.jsx
@@ -397,6 +397,9 @@ export default function AssetStatus() {
     setShowRentalModal(false);
     setPendingStageAssetId(null);
     setPendingNextStage(null);
+
+    // BE에서 계약 생성 후 자산 상태가 자동으로 업데이트되므로 자산 목록 새로고침
+    await refreshAssetList();
   };
 
   // rental create submit handled by hook version; wire context when calling
@@ -419,6 +422,22 @@ export default function AssetStatus() {
   };
 
   // Date formatting handled by utils/date
+
+  // 자산 목록 새로고침 함수 (계약 생성/수정 후 BE에서 자산 상태가 자동 업데이트되므로 호출)
+  const refreshAssetList = React.useCallback(async () => {
+    try {
+      // Prefer lightweight summary for table; gracefully fall back
+      let list = await fetchAssetsSummary().catch(() => null);
+      if (!Array.isArray(list)) {
+        list = await fetchAssets();
+      }
+      let next = Array.isArray(list) ? list.map((a) => withManagementStage({ ...a })) : [];
+      setRows(next);
+    } catch (e) {
+      console.error('Failed to load assets', e);
+      setRows([]);
+    }
+  }, []);
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
## 변경 내용

BE에서 자산 상태 자동 업데이트 기능이 완료되어 FE에서 연동 작업을 진행했습니다.

### 구현 내용
1. **자산 데이터 변환 개선**: `transformAsset` 함수에서 BE에서 반환하는 `status`와 `statusUpdatedAt` 필드를 유지하도록 수정
   - `status`: 자산 상태 ("대여중", "대기", "예약중", "도난", "연체")
   - `statusUpdatedAt`: 상태 업데이트 시각 (Date 객체로 변환)

2. **계약 생성 후 자산 목록 자동 새로고침**: 계약 생성 후 BE에서 자산 상태가 자동으로 업데이트되므로, 자산 목록을 새로고침하여 최신 상태를 반영하도록 수정
   - `refreshAssetList` 함수 추가
   - `handleRentalCreateSubmit`에서 계약 생성 완료 후 자산 목록 새로고침

### 관련 이슈
- #48

### 테스트
- [x] 코드 검증 완료: `transformAsset`에서 status, statusUpdatedAt 필드 유지 확인
- [x] 코드 검증 완료: 계약 생성 후 `refreshAssetList` 호출 확인
- [ ] 실제 동작 테스트: 자산 데이터가 있을 때 계약 생성 후 자산 상태 자동 반영 확인 (자산 데이터 필요)
- [ ] 상태 값이 올바르게 표시되는지 확인 ("대여중", "대기", "예약중", "도난", "연체")