### PR TITLE
fix: 고객센터 문의 내용 입력 필드 추가

### DIFF
--- a/src/components/support/SupportRequestForm.jsx
+++ b/src/components/support/SupportRequestForm.jsx
@@ -298,21 +298,38 @@ export default function SupportRequestForm({
 
         {/* 내용 */}
         <div className="support-form-row-inline" style={{ alignItems: 'flex-start' }}>
-          <label className="support-form-label-side" style={{ paddingTop: 10 }}>
+          <label className="support-form-label-side" style={{ paddingTop: 10 }} htmlFor="support-message">
             내용
           </label>
-          <div className="support-content-box">
-            <span className="support-content-text">
-              서비스 이용, 장애 신고, 결제·정산, 계정·권한 등 운영 관련 문의를 남겨주시면 담당자가 답변을 드립니다.
-            </span>
-            <br />
-            <span className="support-content-text">
-              문제가 발생한 화면, 상황, 발생 시간 등을 최대한 자세히 적어주세요.
-            </span>
-            <br />
-            <span className="support-content-warning">
-              주민번호나 계좌번호 등 민감한 정보는 입력하지 마세요.
-            </span>
+          <div className="support-content-wrapper">
+            <div className="support-content-box support-content-box--info">
+              <span className="support-content-text">
+                서비스 이용, 장애 신고, 결제·정산, 계정·권한 등 운영 관련 문의를 남겨주시면 담당자가 답변을 드립니다.
+              </span>
+              <br />
+              <span className="support-content-text">
+                문제가 발생한 화면, 상황, 발생 시간 등을 최대한 자세히 적어주세요.
+              </span>
+              <br />
+              <span className="support-content-warning">
+                주민번호나 계좌번호 등 민감한 정보는 입력하지 마세요.
+              </span>
+            </div>
+            <textarea
+              id="support-message"
+              className="support-form-textarea"
+              value={form.message}
+              onChange={(e) => updateField("message", e.target.value)}
+              placeholder="문의 내용을 입력하세요"
+              rows={6}
+              required
+            />
+            {fieldErrors.message && (
+              <div className="support-field-error">
+                <ErrorIconSmall />
+                {fieldErrors.message}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/pages/SupportCenter.css
+++ b/src/pages/SupportCenter.css
@@ -264,6 +264,14 @@
     border-color: #006CEC;
 }
 
+/* Content Wrapper */
+.support-content-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 /* Content Box */
 .support-content-box {
     flex: 1;
@@ -273,6 +281,37 @@
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 4px;
     box-sizing: border-box;
+}
+
+.support-content-box--info {
+    min-height: auto;
+    background: #FAFAFA;
+}
+
+/* Message Textarea */
+.support-form-textarea {
+    width: 100%;
+    min-height: 140px;
+    padding: 15px;
+    background: white;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 4px;
+    font-size: 14px;
+    font-family: 'Pretendard', sans-serif;
+    font-weight: 400;
+    color: #1C1C1C;
+    line-height: 24px;
+    box-sizing: border-box;
+    resize: vertical;
+}
+
+.support-form-textarea::placeholder {
+    color: #888888;
+}
+
+.support-form-textarea:focus {
+    outline: none;
+    border-color: #006CEC;
 }
 
 .support-content-text {
@@ -472,6 +511,20 @@
     border-color: #334155;
 }
 
+[data-theme='dark'] .support-content-box--info {
+    background: #0f172a;
+}
+
+[data-theme='dark'] .support-form-textarea {
+    background: #0f172a;
+    border-color: #334155;
+    color: #f1f5f9;
+}
+
+[data-theme='dark'] .support-form-textarea::placeholder {
+    color: #64748b;
+}
+
 [data-theme='dark'] .support-content-text {
     color: #94a3b8;
 }
@@ -518,7 +571,9 @@
 
     .support-select-wrapper,
     .support-form-input-wide,
-    .support-content-box {
+    .support-content-box,
+    .support-content-wrapper,
+    .support-form-textarea {
         width: 100%;
     }
 


### PR DESCRIPTION
## 요약
- 고객센터 페이지의 "문의하기" 섹션에 누락되어 있던 "내용" 입력 필드(textarea)를 추가했습니다.

## 변경 사항
- `SupportRequestForm.jsx`: textarea 컴포넌트 추가 및 form.message 상태 연결
- `SupportCenter.css`: textarea 스타일링 (라이트/다크모드, 반응형 지원)

## 수정 내역
1. 내용 입력용 textarea 추가
2. 입력 안내 텍스트와 textarea를 수직 배치하는 wrapper 구조로 변경
3. 유효성 검사 에러 메시지 표시 기능 추가
4. 다크모드 스타일 적용
5. 반응형 레이아웃 지원

## 테스트 계획
- [x] 고객센터 페이지에서 내용 입력 필드 표시 확인
- [x] textarea에 텍스트 입력 가능 여부 확인
- [x] 콘솔 에러 없음 확인
- [x] 다크모드 스타일 적용 확인 (추가 테스트 권장)

## 검증
- `.env` 파일의 QA 계정을 사용하여 Playwright MCP로 검증 완료

Closes #95