### PR TITLE
fix: page-header-sticky 다크모드 스타일 추가 (#89)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5858,6 +5858,10 @@ html {
   background: #0b1220;
 }
 
+[data-theme='dark'] .page-header-sticky {
+  background: #0f172a;
+}
+
 [data-theme='dark'] .top-header__logout-btn {
   background: #111827;
   border-color: #1f2937;


### PR DESCRIPTION
## 변경 내용

page-header-sticky 클래스에 다크모드 스타일이 누락된 문제를 수정했습니다.

### 변경 사항
- `page-header-sticky` 클래스에 다크모드 배경색 추가
- 다크모드에서 일관된 배경색 적용 (`#0f172a`)

## 테스트

다크모드에서 page-header-sticky가 적용된 페이지에서 배경색이 정상적으로 표시되는지 확인했습니다.

**참고**: QA 계정 정보는 `.env` 파일에서 로드하여 사용했습니다.

## 관련 이슈

Closes #89