### PR TITLE
fix: #106 - 대시보드 모바일 범례 정렬 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7426,11 +7426,13 @@ html {
 
   .dashboard-legend__item {
     min-width: auto;
-    justify-content: flex-start;
+    justify-content: space-between;
     gap: 8px;
   }
 
   .dashboard-legend__label-wrap {
+    flex: 1;
+    min-width: 0;
     gap: 8px;
   }
 


### PR DESCRIPTION
## Summary
- 모바일 뷰에서 대시보드 범례(legend) 정렬을 웹 뷰와 동일하게 수정
- 레이블과 숫자가 각 셀 내에서 양쪽 정렬(space-between)되도록 변경

## Changes
- `.dashboard-legend__item`: `justify-content: flex-start` → `space-between`
- `.dashboard-legend__label-wrap`: `flex: 1`, `min-width: 0` 추가

## Test plan
- [x] 모바일 뷰포트(375px)에서 대시보드 접속
- [x] 자산 현황 범례 정렬 확인
- [x] 계약 현황 범례 정렬 확인

Closes #106