### PR TITLE
fix: #54 - 차종 필터 팝오버 잘림 문제 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,7 @@
 :root {
   --app-header-height: 60px;
   --total-vertical-offset: 250px; /* header + page padding + toolbar + margins */
+  --filter-popover-min-height: 500px; /* Issue #54: 필터 팝오버 높이 보장 */
   /* Shared badge typography for consistent look */
   --badge-font-size: 0.8rem;
   --badge-font-weight: 400;
@@ -255,6 +256,20 @@ body {
   .table-wrap--sticky
   > .table-wrap {
   min-height: 0; /* override base .table-wrap min-height so flex sizing works */
+}
+
+/* Issue #54: 필터가 열릴 때 테이블 최소 높이 보장 (팝오버 잘림 방지) */
+.page--sticky-header
+  .page-scroll.page-scroll--with-sticky-table
+  .table-wrap--sticky:has(.table-wrap--filter-open) {
+  min-height: var(--filter-popover-min-height, 500px);
+}
+
+.page--sticky-header
+  .page-scroll.page-scroll--with-sticky-table
+  .table-wrap--sticky
+  > .table-wrap.table-wrap--filter-open {
+  min-height: var(--filter-popover-min-height, 500px);
 }
 
 /* NOTE: Do not force outer scrolling here.


### PR DESCRIPTION
## Summary
- 자산 현황 페이지에서 검색 결과가 적을 때 차종 필터 팝오버가 잘리는 문제 수정
- 필터가 열릴 때 테이블 영역의 최소 높이(500px)를 보장하여 팝오버가 완전히 표시되도록 함

## Changes
- CSS 변수 `--filter-popover-min-height` 추가
- `.table-wrap--filter-open` 상태에서 min-height 규칙 적용

## Test plan
- [ ] 검색 결과 0개일 때 차종 필터 열기 → 팝오버 완전히 보임
- [ ] 검색 결과 1-3개일 때 차종 필터 열기 → 팝오버 잘리지 않음
- [ ] 데이터 많을 때 → 기존 동작과 동일
- [ ] 필터 닫힌 상태 → 기존 레이아웃 유지

Closes #54