### PR TITLE
fix: #56 - 컬럼설정 버튼 글씨색 변경

### DIFF
--- a/src/components/ColumnSettingsMenu.jsx
+++ b/src/components/ColumnSettingsMenu.jsx
@@ -86,7 +86,7 @@ export default function ColumnSettingsMenu({
             }} />
           </div>
           <div style={{
-            color: '#888888',
+            color: '#1C1C1C',
             fontSize: 14,
             fontFamily: 'Pretendard',
             fontWeight: 500,
@@ -120,7 +120,7 @@ export default function ColumnSettingsMenu({
               }} />
             </div>
             <div style={{
-              color: '#888888',
+              color: '#1C1C1C',
               fontSize: 14,
               fontFamily: 'Pretendard',
               fontWeight: 500,


### PR DESCRIPTION
## Summary
- 컬럼설정 메뉴의 "초기화" 및 "전체 선택 해제" 버튼 글씨색을 `#888888`에서 `#1C1C1C`로 변경
- 비활성화 버튼처럼 보이던 문제 해결

## Test plan
- [ ] 개발 서버 실행 후 Asset Status 페이지 접속
- [ ] "컬럼설정" 버튼 클릭하여 드롭다운 열기
- [ ] "초기화" 및 "전체 선택 해제" 버튼 텍스트가 컬럼명과 동일한 색상인지 확인

closes #56