### PR TITLE
fix: #62 #65 - 사고 버튼 텍스트를 '사고정보조회'로 변경

### DIFF
--- a/src/pages/RentalContracts.jsx
+++ b/src/pages/RentalContracts.jsx
@@ -1300,7 +1300,7 @@ export default function RentalContracts() {
                 />
               </svg>
             )}
-            {hasAccident ? '사고확인' : '사고등록'}
+            {hasAccident ? '사고정보조회' : '사고등록'}
           </button>
         );
       }
@@ -1808,7 +1808,7 @@ export default function RentalContracts() {
                     </linearGradient>
                   </defs>
                 </svg>
-                {selectedContract.accidentReported ? '사고정보수정' : '사고등록'}
+                {selectedContract.accidentReported ? '사고정보조회' : '사고등록'}
               </button>
               {(() => {
                 const now = new Date();


### PR DESCRIPTION
## Summary
- 테이블 셀 버튼: `사고확인` → `사고정보조회`
- 상세 모달 버튼: `사고정보수정` → `사고정보조회`

사고정보 조회 모달이 읽기전용이므로 버튼 텍스트를 실제 동작에 맞게 변경

## Related Issues
- Closes #62
- Closes #65

## Test Plan
- [ ] 계약 목록에서 사고가 등록된 계약의 버튼 텍스트가 "사고정보조회"로 표시되는지 확인
- [ ] 계약 상세 모달에서 사고가 등록된 계약의 버튼 텍스트가 "사고정보조회"로 표시되는지 확인
- [ ] 버튼 클릭 시 사고정보 조회 모달이 정상적으로 열리는지 확인