### PR TITLE
fix: #108 - 관리상태 변경 후 계약등록관리 매칭 불일치 수정

### DIFF
--- a/src/hooks/useManagementStage.js
+++ b/src/hooks/useManagementStage.js
@@ -43,9 +43,14 @@ export default function useManagementStage(options) {
       } catch (e) {
           console.warn("Failed to fetch rentals for VIN using resolveVehicleRentals", e);
           // Fallback to fetchRentals if resolveVehicleRentals fails
-          let rentals = await fetchRentals();
-          const list = Array.isArray(rentals) ? rentals : [];
-
+          try {
+            const rentals = await fetchRentals();
+            const list = Array.isArray(rentals) ? rentals : [];
+            // Filter by VIN and assign to allRentalsForVin
+            allRentalsForVin = list.filter(r => String(r?.vin || '') === String(asset.vin || ''));
+          } catch (fallbackErr) {
+            console.warn("Fallback fetchRentals also failed", fallbackErr);
+          }
       }
 
       const openForVin = allRentalsForVin.filter((r) => {


### PR DESCRIPTION
## Summary
- 관리상태를 "대여가능"으로 변경 시 경고 아이콘이 잘못 표시되는 문제 수정
- 계약 생성/관리상태 변경 후 rental index가 갱신되지 않는 문제 수정

## Changes
### `src/hooks/useManagementStage.js`
- `resolveVehicleRentals` API 실패 시 `fetchRentals()` fallback에서 VIN 기준으로 필터하여 `allRentalsForVin`에 할당
- 기존에는 fallback 결과가 `list` 변수에만 저장되고 `allRentalsForVin`에 할당되지 않아 확인 다이얼로그가 표시되지 않았음

### `src/pages/AssetStatus.jsx`
- `refreshRentalIndex` 함수 추가하여 rental consistency index를 갱신할 수 있도록 함
- `handleManagementStageChangeWithRefresh` wrapper 추가하여 관리상태 변경 후 rental index 갱신
- `handleRentalCreateSubmit`에서 계약 생성 후 `refreshRentalIndex()` 호출 추가

## Test plan
- [ ] "대여중" → "대여가능" 관리상태 변경 시 확인 다이얼로그 표시 확인
- [ ] 확인 후 경고 아이콘이 사라지는지 확인
- [ ] 새 계약 생성 후 관리상태와 경고 아이콘이 올바르게 표시되는지 확인

Closes #108