### PR TITLE
fix: #57 - 차량상태 필터 드롭다운 폭 증가

### DIFF
--- a/src/components/filters/VehicleStatusFilterDropdown.jsx
+++ b/src/components/filters/VehicleStatusFilterDropdown.jsx
@@ -34,7 +34,7 @@ export default function VehicleStatusFilterDropdown({ value, onChange, onClear, 
       data-layer="Dropdown_차량상태"
       className="Dropdown"
       style={{
-        width: 130,
+        width: 160,
         height: 190,
         position: 'relative',
       }}
@@ -44,7 +44,7 @@ export default function VehicleStatusFilterDropdown({ value, onChange, onClear, 
         data-layer="Rectangle 12"
         className="Rectangle12"
         style={{
-          width: 130,
+          width: 160,
           height: 190,
           left: 0,
           top: 0,
@@ -61,7 +61,7 @@ export default function VehicleStatusFilterDropdown({ value, onChange, onClear, 
         data-layer="Line 3"
         className="Line3"
         style={{
-          width: 90,
+          width: 120,
           height: 0,
           left: 20,
           top: 50,
@@ -76,7 +76,7 @@ export default function VehicleStatusFilterDropdown({ value, onChange, onClear, 
         data-layer="Frame 427319158"
         className="Frame427319158"
         style={{
-          width: 90,
+          width: 120,
           left: 20,
           top: 60,
           position: 'absolute',
@@ -174,7 +174,7 @@ export default function VehicleStatusFilterDropdown({ value, onChange, onClear, 
         data-layer="Frame 427319149"
         className="Frame427319149"
         style={{
-          width: 90,
+          width: 120,
           left: 20,
           top: 20,
           position: 'absolute',


### PR DESCRIPTION
## Summary
- 차량상태 필터 드롭다운 폭이 너무 좁아 내용이 잘리는 문제 수정

## Changes
### `src/components/filters/VehicleStatusFilterDropdown.jsx`
- 드롭다운 컨테이너 폭: 130px → 160px
- 배경 컨테이너 폭: 130px → 160px
- 구분선 폭: 90px → 120px
- 상태 옵션 목록 폭: 90px → 120px
- 새로고침 버튼 영역 폭: 90px → 120px

## Test plan
- [ ] 차량상태 필터 드롭다운에서 모든 옵션 텍스트가 잘리지 않고 보임
- [ ] 라디오 버튼과 텍스트 사이 충분한 간격 확보
- [ ] 새로고침 버튼 영역도 정상 표시

Closes #57