### PR TITLE
feat: 계약 상태머신 FE 반영 및 터미널 상태 정렬

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ npm run preview  # 빌드 미리보기
 - 성공 응답: `{ status: "success", data: { recipients: [...], submitted: {...} } }`
 - 오류: `400 VALIDATION_ERROR` 시 `details` 배열 제공, `503 EMAIL_NOT_CONFIGURED`, `502/503 EMAIL_FAILED`(메일 재시도/문의 필요)
 
+## 계약 상태 전환 연동
+- 상태는 서버 상태머신(`contractStatus`) 기준으로 사용합니다.
+- 전환 API:
+  - `POST /rentals/:id/transition` 요청: `{ action, payload? }`
+  - `GET /rentals/:id/transitions` 응답: `{ currentState, allowedActions, stateHistory }`
+- 렌탈 상세 API `GET /rentals/:id` 응답에도 `allowedActions`, `stateHistory`가 포함될 수 있습니다.
+- 대표 오류:
+  - `409 CONFLICT`: 동시 전환 충돌(최신 상태 재조회 후 재시도)
+  - `422 INVALID_TRANSITION`: 현재 상태에서 허용되지 않는 액션
+
 ## 폴더 구조(요약)
 ```
 src/

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -450,7 +449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -474,7 +472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1864,7 +1861,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1993,13 +1991,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2137,7 +2128,6 @@
       "integrity": "sha512-F9jI5rSstNknPlTlPN2gcc4gpbaagowuRzw/OJzl368dvPun668Q182S8Q8P9PITgGCl5LAKXpzuue106eM4wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.8",
         "fflate": "^0.8.2",
@@ -2174,7 +2164,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2518,7 +2507,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2593,9 +2581,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001739",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-      "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+      "version": "1.0.30001767",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
+      "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
       "dev": true,
       "funding": [
         {
@@ -2610,7 +2598,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.0",
@@ -2792,13 +2781,6 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -3128,7 +3110,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3450,7 +3433,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4801,7 +4783,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -5239,6 +5220,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5641,7 +5623,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5679,7 +5660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5728,6 +5708,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5743,6 +5724,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5755,7 +5737,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5811,7 +5794,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5823,7 +5805,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5853,7 +5834,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5956,8 +5936,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7019,7 +6998,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7095,7 +7073,6 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",

--- a/src/App.css
+++ b/src/App.css
@@ -1560,6 +1560,76 @@ body {
   color: #eb4a45;
 }
 
+.badge--contract-inquiry {
+  background: rgba(100, 116, 139, 0.14);
+  color: #475569;
+}
+
+.badge--contract-reserved {
+  background: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+}
+
+.badge--contract-checkout-pending {
+  background: rgba(245, 158, 11, 0.18);
+  color: #b45309;
+}
+
+.badge--contract-active {
+  background: rgba(22, 163, 74, 0.14);
+  color: #15803d;
+}
+
+.badge--contract-extension {
+  background: rgba(234, 88, 12, 0.14);
+  color: #c2410c;
+}
+
+.badge--contract-return-pending {
+  background: rgba(124, 58, 237, 0.14);
+  color: #6d28d9;
+}
+
+.badge--contract-closed {
+  background: rgba(55, 65, 81, 0.14);
+  color: #374151;
+}
+
+.badge--contract-canceled {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.badge--contract-no-show {
+  background: transparent;
+  border: 1px solid rgba(185, 28, 28, 0.5);
+  color: #991b1b;
+}
+
+.contract-action-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.contract-action-chip {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #1e293b;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+
+.contract-action-chip:hover {
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
 /* Rental amount cell (contracts) */
 .rental-amount-cell {
   display: flex;
@@ -6105,6 +6175,48 @@ html {
   color: #fca5a5;
 }
 
+[data-theme='dark'] .badge--contract-inquiry {
+  background: #1f2937;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .badge--contract-reserved {
+  background: #102a56;
+  color: #93c5fd;
+}
+
+[data-theme='dark'] .badge--contract-checkout-pending,
+[data-theme='dark'] .badge--contract-extension {
+  background: #3a2210;
+  color: #fdba74;
+}
+
+[data-theme='dark'] .badge--contract-active {
+  background: #0f2e23;
+  color: #86efac;
+}
+
+[data-theme='dark'] .badge--contract-return-pending {
+  background: #2e1065;
+  color: #c4b5fd;
+}
+
+[data-theme='dark'] .badge--contract-closed {
+  background: #1f2937;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .badge--contract-canceled {
+  background: #3a1214;
+  color: #fca5a5;
+}
+
+[data-theme='dark'] .badge--contract-no-show {
+  background: transparent;
+  border-color: rgba(252, 165, 165, 0.6);
+  color: #fecaca;
+}
+
 [data-theme='dark'] .badge--accident {
   background: #3a2210;
   color: #fdba74;
@@ -6618,6 +6730,166 @@ html {
   cursor: not-allowed;
 }
 
+.workflow-action-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.workflow-action-btn {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #1e293b;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.workflow-action-btn.is-active {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.workflow-panel {
+  margin-top: 12px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.workflow-panel__title {
+  font-weight: 700;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.workflow-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 12px;
+}
+
+.workflow-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.workflow-field input {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.workflow-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #1e293b;
+}
+
+.workflow-panel__actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+}
+
+.workflow-submit-btn,
+.workflow-cancel-btn {
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.workflow-submit-btn {
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.workflow-cancel-btn {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #334155;
+}
+
+.contract-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contract-timeline__item {
+  display: flex;
+  gap: 10px;
+}
+
+.contract-timeline__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  margin-top: 6px;
+  background: #2563eb;
+  flex: 0 0 auto;
+}
+
+.contract-timeline__content {
+  flex: 1;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px;
+}
+
+.contract-timeline__main {
+  font-size: 13px;
+  font-weight: 700;
+  color: #0f172a;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.contract-timeline__arrow {
+  color: #64748b;
+}
+
+.contract-timeline__meta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.contract-timeline__payload {
+  margin: 8px 0 0;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  padding: 8px;
+  white-space: pre-wrap;
+  font-size: 11px;
+  color: #334155;
+}
+
+.contract-timeline__empty {
+  font-size: 13px;
+  color: #64748b;
+}
+
+@media (max-width: 900px) {
+  .workflow-fields {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Section */
 .rental-detail__section {
   margin-bottom: 20px;
@@ -6830,6 +7102,78 @@ html {
 
 [data-theme='dark'] .rental-detail__action-btn--outline {
   color: #ffffff;
+}
+
+[data-theme='dark'] .contract-action-chip {
+  background: #0f172a;
+  border-color: #334155;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .contract-action-chip:hover {
+  background: #1e293b;
+  border-color: #475569;
+}
+
+[data-theme='dark'] .workflow-action-btn {
+  background: #0f172a;
+  border-color: #334155;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .workflow-action-btn.is-active {
+  background: #172554;
+  border-color: #1d4ed8;
+  color: #bfdbfe;
+}
+
+[data-theme='dark'] .workflow-panel {
+  background: #0f172a;
+  border-color: #334155;
+}
+
+[data-theme='dark'] .workflow-panel__title,
+[data-theme='dark'] .workflow-field,
+[data-theme='dark'] .workflow-check {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .workflow-field input {
+  background: #020617;
+  border-color: #334155;
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .workflow-submit-btn {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+[data-theme='dark'] .workflow-cancel-btn {
+  background: #0f172a;
+  border-color: #334155;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .contract-timeline__content {
+  background: #0f172a;
+  border-color: #334155;
+}
+
+[data-theme='dark'] .contract-timeline__main {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .contract-timeline__meta,
+[data-theme='dark'] .contract-timeline__empty,
+[data-theme='dark'] .contract-timeline__arrow {
+  color: #94a3b8;
+}
+
+[data-theme='dark'] .contract-timeline__payload {
+  background: #020617;
+  border-color: #334155;
+  color: #cbd5e1;
 }
 
 /* ==================== 사고 등록 모달 (Accident Registration Modal) ==================== */

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -160,7 +160,9 @@ async function apiRequest(endpoint, options = {}) {
 
         if (!response.ok) {
             const errorType = payload?.error?.type;
-            const err = new Error(`HTTP ${status}: ${response.statusText}`);
+            const err = new Error(
+                payload?.error?.message || payload?.message || `HTTP ${status}: ${response.statusText}`
+            );
             // Preserve status details for upper-layer error handling
             err.status = status;
             err.statusText = response.statusText;
@@ -535,6 +537,40 @@ export const rentalsApi = {
         }
         const rid = sanitizeId(id);
         return await apiRequest(API_ENDPOINTS.RENTAL_ACCIDENT_DETAIL(rid));
+    },
+
+    async transition(id, action, payload = {}) {
+        if (!validateId(id) && typeof id !== 'number') {
+            return createApiResponse(null, API_STATUS.ERROR, {
+                type: 'VALIDATION_ERROR',
+                message: 'Invalid rental ID'
+            });
+        }
+        if (!action || typeof action !== 'string') {
+            return createApiResponse(null, API_STATUS.ERROR, {
+                type: 'VALIDATION_ERROR',
+                message: 'Invalid transition action'
+            });
+        }
+        const rid = sanitizeId(id);
+        return await apiRequest(API_ENDPOINTS.RENTAL_TRANSITION(rid), {
+            method: 'POST',
+            body: JSON.stringify({
+                action: String(action).trim(),
+                payload: payload && typeof payload === 'object' ? payload : {}
+            })
+        });
+    },
+
+    async fetchTransitions(id) {
+        if (!validateId(id) && typeof id !== 'number') {
+            return createApiResponse(null, API_STATUS.ERROR, {
+                type: 'VALIDATION_ERROR',
+                message: 'Invalid rental ID'
+            });
+        }
+        const rid = sanitizeId(id);
+        return await apiRequest(API_ENDPOINTS.RENTAL_TRANSITIONS(rid));
     }
 };
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,6 +26,8 @@ export const {
   deleteRental,
   fetchRentalMemoHistory,
   fetchRentalAccidentDetail,
+  transitionRentalState,
+  fetchRentalTransitions,
   fetchVehicles,
   buildRentalIndexByVin,
   resolveVehicleRentals,

--- a/src/components/badges/StatusBadge.jsx
+++ b/src/components/badges/StatusBadge.jsx
@@ -48,15 +48,18 @@ const StatusBadge = ({ type, variant, children, className = "", style = {} }) =>
 
 const RentalStatusBadge = ({ status }) => {
   const getStatusConfig = () => {
-    if (status === "도난 의심") {
-      return { type: "suspicious", text: "도난 의심" };
-    } else if (status?.startsWith("연체")) {
-      return { type: "overdue", text: status };
-    } else if (status === "대여 중") {
-      return { type: "rented", text: "대여 중" };
-    } else {
-      return { type: "available", text: status || "-" };
-    }
+    const map = {
+      문의: { type: "contract-inquiry", text: "문의" },
+      예약확정: { type: "contract-reserved", text: "예약확정" },
+      체크아웃대기: { type: "contract-checkout-pending", text: "체크아웃대기" },
+      대여중: { type: "contract-active", text: "대여중" },
+      연장요청: { type: "contract-extension", text: "연장요청" },
+      반납대기: { type: "contract-return-pending", text: "반납대기" },
+      종결: { type: "contract-closed", text: "종결" },
+      취소: { type: "contract-canceled", text: "취소" },
+      노쇼: { type: "contract-no-show", text: "노쇼" },
+    };
+    return map[status] || { type: "default", text: status || "-" };
   };
 
   const config = getStatusConfig();

--- a/src/components/modals/RentalCreateModal.jsx
+++ b/src/components/modals/RentalCreateModal.jsx
@@ -8,7 +8,6 @@ import { randomId } from "../../utils/id";
 import generateContractNumber from "../../utils/rentalId";
 import { useAuth } from "../../contexts/AuthContext";
 import { useCompany } from "../../contexts/CompanyContext";
-import StatusBadge from "../badges/StatusBadge";
 import FilesPreviewCarousel from "../FilesPreviewCarousel";
 import FilePreview from "../FilePreview";
 import "./RentalCreateModal.css";
@@ -61,6 +60,7 @@ const RentalCreateModal = ({ isOpen, onClose, onSubmit, initial = {} }) => {
         deposit: initial.deposit || "",
         paymentMethod: initial.paymentMethod || "월별 자동이체",
         rentalType: initial.rentalType || "장기",
+        contractStatus: initial.contractStatus || "예약확정",
         contractFile: null,
         driverLicenseFile: null,
     });
@@ -124,6 +124,7 @@ const RentalCreateModal = ({ isOpen, onClose, onSubmit, initial = {} }) => {
                 deposit: initial.deposit || "",
                 paymentMethod: initial.paymentMethod || "월별 자동이체",
                 rentalType: initial.rentalType || "장기",
+                contractStatus: initial.contractStatus || "예약확정",
                 contractFile: null,
                 driverLicenseFile: null,
             });
@@ -470,6 +471,21 @@ const RentalCreateModal = ({ isOpen, onClose, onSubmit, initial = {} }) => {
                     <div className="rental-create-modal__contract-number">
                         <span className="rental-create-modal__contract-number-label">대여 계약번호</span>
                         <span className="rental-create-modal__contract-number-value">{contractNumber}</span>
+                    </div>
+
+                    <div className="rental-create-modal__form-row">
+                        <label className="rental-create-modal__form-label">초기 계약 상태</label>
+                        <div className="rental-create-modal__select-wrapper rental-create-modal__select-wrapper--wide">
+                            <select
+                                value={form.contractStatus}
+                                onChange={(e) => update("contractStatus", e.target.value)}
+                                className="rental-create-modal__select"
+                            >
+                                <option value="예약확정">예약확정 (기본)</option>
+                                <option value="문의">문의</option>
+                            </select>
+                            <DropdownIcon />
+                        </div>
                     </div>
 
                     {/* Renter Name & Contact */}

--- a/src/constants/contractState.js
+++ b/src/constants/contractState.js
@@ -1,0 +1,53 @@
+export const CONTRACT_STATUSES = [
+  "문의",
+  "예약확정",
+  "체크아웃대기",
+  "대여중",
+  "연장요청",
+  "반납대기",
+  "종결",
+  "취소",
+  "노쇼",
+];
+
+export const CONTRACT_TERMINAL_STATUSES = new Set(["종결", "취소", "노쇼"]);
+
+export const CONTRACT_STATUS_BADGE_TYPE = {
+  문의: "contract-inquiry",
+  예약확정: "contract-reserved",
+  체크아웃대기: "contract-checkout-pending",
+  대여중: "contract-active",
+  연장요청: "contract-extension",
+  반납대기: "contract-return-pending",
+  종결: "contract-closed",
+  취소: "contract-canceled",
+  노쇼: "contract-no-show",
+};
+
+export const CONTRACT_ACTION_LABELS = {
+  create_inquiry: "문의 등록",
+  create_reserved: "예약 등록",
+  confirm: "예약 확정",
+  start_checkout: "체크아웃 시작",
+  cancel: "취소",
+  no_show: "노쇼 처리",
+  handover: "인수 완료",
+  request_extension: "연장 요청",
+  initiate_return: "반납 접수",
+  approve_extension: "연장 승인",
+  reject_extension: "연장 거절",
+  complete_inspection: "검수/정산 완료",
+  cancel_return: "반납 취소",
+};
+
+export function getContractActionLabel(action) {
+  return CONTRACT_ACTION_LABELS[action] || action || "-";
+}
+
+export function normalizeContractStatus(status) {
+  if (!status) return "";
+  const s = String(status).trim();
+  if (s === "예약" || s === "예약중") return "예약확정";
+  if (s === "완료") return "종결";
+  return s;
+}

--- a/src/hooks/useManagementStage.js
+++ b/src/hooks/useManagementStage.js
@@ -3,6 +3,7 @@ import { useConfirm } from "../contexts/ConfirmContext";
 import { fetchRentals, fetchRentalsSummary, updateRental, saveAsset, createRental, resolveVehicleRentals } from "../api";
 import { uploadMany } from "../utils/uploadHelpers";
 import { emitToast } from "../utils/toast";
+import { CONTRACT_TERMINAL_STATUSES, normalizeContractStatus } from "../constants/contractState";
 
 // Extracts management stage transitions and the rental-create follow-up flow.
 // Requires several state setters so it can coordinate UI with API work.
@@ -55,7 +56,8 @@ export default function useManagementStage(options) {
 
       const openForVin = allRentalsForVin.filter((r) => {
         const returnedAt = r?.returnedAt ? new Date(r.returnedAt) : null;
-        return !(returnedAt && now >= returnedAt) && r?.contractStatus !== "완료";
+        const normalizedStatus = normalizeContractStatus(r?.contractStatus);
+        return !(returnedAt && now >= returnedAt) && !CONTRACT_TERMINAL_STATUSES.has(normalizedStatus);
       });
 
       const startOf = (r) => (r?.rentalPeriod?.start ? new Date(r.rentalPeriod.start) : null);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,10 +4,21 @@ import { fetchDashboardData } from "../api";
 import useApprovalQueryEffects from "../hooks/useApprovalQueryEffects";
 import StatusDonut from "../components/charts/StatusDonut";
 import TerminalRequestModal from "../components/modals/TerminalRequestModal";
+import { CONTRACT_STATUSES } from "../constants/contractState";
 
 // Colors aligned with Figma asset status donut
 const ASSET_COLORS = ["#1D4693", "#1A53EF", "#3690FF", "#78B5FF", "#A9D0FF"];
-const CONTRACT_COLORS = ["#22C55E", "#4ADE80", "#86EFAC"]; // green shades
+const CONTRACT_COLORS = [
+    "#64748B", // 문의
+    "#2563EB", // 예약확정
+    "#F59E0B", // 체크아웃대기
+    "#16A34A", // 대여중
+    "#EA580C", // 연장요청
+    "#7C3AED", // 반납대기
+    "#374151", // 종결
+    "#DC2626", // 취소
+    "#B91C1C", // 노쇼
+];
 
 export default function Dashboard() {
     const [vehicleStatus, setVehicleStatus] = useState([]);
@@ -35,10 +46,10 @@ export default function Dashboard() {
 
                 // 계약 현황
                 const contractCounts = summary.contractStatusCounts || {};
-                const contractDist = Object.entries(contractCounts).map(([name, value]) => ({
+                const contractDist = CONTRACT_STATUSES.map((name) => ({
                     name,
-                    value: Number(value) || 0,
-                    rawValue: Number(value) || 0
+                    value: Number(contractCounts[name]) || 0,
+                    rawValue: Number(contractCounts[name]) || 0,
                 }));
                 setBizStatusLabeled(contractDist.filter((d) => (d?.value ?? 0) > 0));
             } catch (e) {

--- a/src/utils/contracts.js
+++ b/src/utils/contracts.js
@@ -1,5 +1,7 @@
 // Contract status utilities
-// Provides a single source of truth for determining a rental's status
+// Server contractStatus is the source of truth. Keep minimal fallbacks only.
+
+import { normalizeContractStatus } from "../constants/contractState";
 
 /**
  * Parse ISO-like date string to Date, returns null on invalid
@@ -24,40 +26,17 @@ export function isReturned(r, now = new Date()) {
 }
 
 /**
- * Compute high-level contract status from rental data.
- * Priority order:
- * - 완료: if returnedAt is in the past
- * - 도난의심: if reportedStolen
- * - 반납지연: now > end and not returned
- * - 대여중: start <= now <= end
- * - 사고접수: accidentReported true
- * - 예약 중: start in future (or default when dates missing)
+ * Resolve contract status.
+ * Uses server-provided status first and only applies a small compatibility fallback.
  * @param {object} r rental row
  * @param {Date} [now]
  * @returns {string}
  */
 export function computeContractStatus(r, now = new Date()) {
-  if (isReturned(r, now)) return "완료";
-  const start = toDate(r?.rentalPeriod?.start);
-  const end = toDate(r?.rentalPeriod?.end);
-  const isStolen = Boolean(r?.reportedStolen);
-
-  if (isStolen) return "도난의심";
-
-  const hasEnd = !!end;
-  const isOverdue = hasEnd && now > end;
-  if (isOverdue) return "반납지연";
-
-  const isActive = !!(start && end && now >= start && now <= end);
-  if (isActive) return "대여중";
-
-  if (r?.accidentReported) return "사고접수";
-
-  const isFuture = !!(start && now < start);
-  if (isFuture) return "예약 중";
-
-  // Fallback
-  return "예약 중";
+  const fromServer = normalizeContractStatus(r?.contractStatus);
+  if (fromServer) return fromServer;
+  if (isReturned(r, now)) return "종결";
+  return "";
 }
 
 /**
@@ -67,17 +46,13 @@ export function computeContractStatus(r, now = new Date()) {
 export function classifyRental(r, now = new Date()) {
   const status = computeContractStatus(r, now);
   switch (status) {
-    case "완료":
+    case "종결":
       return "COMPLETED";
-    case "도난의심":
-      return "STOLEN";
-    case "반납지연":
-      return "OVERDUE";
     case "대여중":
       return "ACTIVE";
-    case "사고접수":
-      return "ACCIDENT";
-    case "예약 중":
+    case "예약확정":
+    case "체크아웃대기":
+    case "문의":
       return "RESERVED";
     default:
       return "UNKNOWN";

--- a/src/utils/contracts.test.js
+++ b/src/utils/contracts.test.js
@@ -1,37 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { computeContractStatus, toDate } from './contracts';
+import { computeContractStatus } from './contracts';
 
 describe('contracts.computeContractStatus', () => {
-  const now = new Date('2025-01-10T12:00:00Z');
+  const now = new Date('2026-02-04T12:00:00Z');
 
-  it('returns 완료 when returnedAt in past', () => {
-    const r = { returnedAt: '2025-01-09T12:00:00Z' };
-    expect(computeContractStatus(r, now)).toBe('완료');
-  });
-
-  it('returns 도난의심 when reportedStolen', () => {
-    const r = { reportedStolen: true };
-    expect(computeContractStatus(r, now)).toBe('도난의심');
-  });
-
-  it('returns 반납지연 when now > end and not returned', () => {
-    const r = { rentalPeriod: { start: '2025-01-01', end: '2025-01-05' } };
-    expect(computeContractStatus(r, now)).toBe('반납지연');
-  });
-
-  it('returns 대여중 when now within start..end', () => {
-    const r = { rentalPeriod: { start: '2025-01-01', end: '2025-01-20' } };
+  it('prefers server status', () => {
+    const r = { contractStatus: '대여중' };
     expect(computeContractStatus(r, now)).toBe('대여중');
   });
 
-  it('returns 사고접수 when accidentReported', () => {
-    const r = { accidentReported: true };
-    expect(computeContractStatus(r, now)).toBe('사고접수');
+  it('normalizes legacy status 예약 to 예약확정', () => {
+    const r = { contractStatus: '예약' };
+    expect(computeContractStatus(r, now)).toBe('예약확정');
   });
 
-  it('returns 예약 중 when start in future', () => {
-    const r = { rentalPeriod: { start: '2025-02-01', end: '2025-02-03' } };
-    expect(computeContractStatus(r, now)).toBe('예약 중');
+  it('normalizes legacy status 완료 to 종결', () => {
+    const r = { contractStatus: '완료' };
+    expect(computeContractStatus(r, now)).toBe('종결');
+  });
+
+  it('falls back to 종결 when returnedAt is in the past', () => {
+    const r = { returnedAt: '2026-02-03T00:00:00Z' };
+    expect(computeContractStatus(r, now)).toBe('종결');
+  });
+
+  it('returns empty when status is missing', () => {
+    expect(computeContractStatus({}, now)).toBe('');
   });
 });
-

--- a/src/utils/managementStage.js
+++ b/src/utils/managementStage.js
@@ -52,10 +52,20 @@ export const getManagementStage = (asset = {}) => {
     const deviceSerial = (asset.deviceSerial || "").trim();
     const totalIssues = getDiagnosticCount(asset);
 
-    if (vehicleStatus === "대여중" || vehicleStatus === "운행중" || vehicleStatus === "반납대기") {
+    if (
+        vehicleStatus === "대여중" ||
+        vehicleStatus === "운행중" ||
+        vehicleStatus === "연장요청" ||
+        vehicleStatus === "반납대기"
+    ) {
         return "대여중";
     }
-    if (vehicleStatus === "예약중") {
+    if (
+        vehicleStatus === "예약중" ||
+        vehicleStatus === "예약 중" ||
+        vehicleStatus === "예약확정" ||
+        vehicleStatus === "체크아웃대기"
+    ) {
         return "예약중";
     }
     if (vehicleStatus === "정비중" || vehicleStatus === "수리중" || vehicleStatus === "점검중" || vehicleStatus === "도난추적") {


### PR DESCRIPTION
## 변경 내용
- 계약 상태머신(9개 상태) 기준으로 FE 상태 처리 로직 정렬
- `transition/transitions` API 연동 및 `allowedActions/stateHistory` 기반 UI 반영
- 렌탈 목록 상태 필터/배지를 신규 상태 체계로 전환
- 렌탈 상세에 상태 전환 워크플로우 패널 및 상태 이력 타임라인 추가
- 생성 모달 초기 상태(`예약확정` 기본, `문의` 선택) 반영
- 대시보드 계약 상태 집계를 신규 상태 체계로 정렬
- 터미널 상태(`종결/취소/노쇼`) 공통 처리 기준으로 `indexByVin` fallback / 관리단계 가드 로직 정렬
- README에 계약 상태 전환 연동 내용 추가

## 이슈 연결
- Closes #114
- Closes #115

## 테스트
- `npm run build`
- `npx vitest run src/utils/contracts.test.js`
