### PR TITLE
feat: 계약 상세페이지 수정 기능 추가

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6956,6 +6956,35 @@ html {
   white-space: nowrap;
 }
 
+.rental-detail__edit-input {
+  flex: 1;
+  height: 44px;
+  padding: 10px 14px;
+  background: #ffffff;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  color: #1c1c1c;
+  font-size: 14px;
+  font-family: 'Pretendard', sans-serif;
+  font-weight: 400;
+  line-height: 24px;
+}
+
+.rental-detail__edit-textarea {
+  flex: 1;
+  min-height: 80px;
+  padding: 10px 14px;
+  background: #ffffff;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  color: #1c1c1c;
+  font-size: 14px;
+  font-family: 'Pretendard', sans-serif;
+  font-weight: 400;
+  line-height: 24px;
+  resize: vertical;
+}
+
 .rental-detail__info-value--status {
   color: #e50e08;
   font-weight: 700;
@@ -7048,6 +7077,13 @@ html {
 [data-theme='dark'] .rental-detail__info-value {
   background: #2a2a3e;
   border-color: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+[data-theme='dark'] .rental-detail__edit-input,
+[data-theme='dark'] .rental-detail__edit-textarea {
+  background: #121a2a;
+  border-color: rgba(255, 255, 255, 0.18);
   color: #ffffff;
 }
 


### PR DESCRIPTION
## 변경 내용
- 계약 상세 모달에 수정 모드를 추가했습니다.
- `admin` 이상 권한에서만 `수정` 버튼이 노출되도록 적용했습니다.
- 수정 버튼 클릭 시 각 필드를 editable 상태로 전환하고 `저장`/`취소` 버튼을 노출합니다.
- 저장 시 변경 필드만 patch로 계산해 `updateRental` API로 저장하도록 구현했습니다.
- 취소 시 draft 변경값을 폐기하고 조회 상태로 복귀하도록 처리했습니다.
- 편집 중 닫기 시 변경 유실 확인 다이얼로그를 추가했습니다.
- 계약 상세 하단에 수정 내역 표출 영역(연동 대기형)을 추가했습니다.

## 테스트
- `npm install`
- `npm run build`
